### PR TITLE
Add edit feature for receita launch screen

### DIFF
--- a/controllers/docController.js
+++ b/controllers/docController.js
@@ -200,3 +200,38 @@ exports.deletarTodos = async (req, res) => {
     }
 };
 
+// Retorna um único lançamento pelo código
+exports.listarDocId = async (req, res) => {
+    const { id } = req.params;
+    try {
+        const result = await pool.query('select * from doc where doccod = $1', [id]);
+        if (result.rows.length === 0) {
+            return res.status(404).json({ error: 'Documento não encontrado' });
+        }
+        res.status(200).json(result.rows[0]);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Erro ao buscar documento' });
+    }
+};
+
+// Edita dados do lançamento
+exports.editarDoc = async (req, res) => {
+    const { id } = req.params;
+    const { doctccod, doccontacod, doccatcod, docv, docobs, docdtpag, docsta } = req.body;
+    const valor = parseFloat(docv.replace(',', '.'));
+    try {
+        const result = await pool.query(
+            'update doc set doctccod=$1, doccontacod=$2, doccatcod=$3, docv=$4, docobs=$5, docdtpag=$6, docsta=$7 where doccod=$8 RETURNING *',
+            [doctccod, doccontacod, doccatcod, valor, docobs, docdtpag, docsta, id]
+        );
+        if (result.rowCount === 0) {
+            return res.status(404).json({ error: 'Documento não encontrado' });
+        }
+        res.status(200).json(result.rows[0]);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Erro ao editar documento' });
+    }
+};
+

--- a/public/html/lancamento_receita.html
+++ b/public/html/lancamento_receita.html
@@ -152,6 +152,54 @@
                                     </tbody>
                                 </table>
                             </div>
+                            <!-- Modal de edição -->
+                            <div class="modal fade" id="modalEditar" tabindex="-1" aria-labelledby="modalEditarLabel" aria-hidden="true">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                        <form id="formEditar">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title" id="modalEditarLabel">Editar Lançamento</h5>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                            </div>
+                                            <div class="modal-body">
+                                                <input type="hidden" id="edit_doccod" name="doccod">
+                                                <div class="form-group mb-2">
+                                                    <label>Conta:</label>
+                                                    <select id="edit_contacod" name="doccontacod" class="form-control" required></select>
+                                                </div>
+                                                <div class="form-group mb-2">
+                                                    <label>Tipo de Cobrança:</label>
+                                                    <select id="edit_tccod" name="doctccod" class="form-control" required></select>
+                                                </div>
+                                                <div class="form-group mb-2">
+                                                    <label>Categoria:</label>
+                                                    <select id="edit_catcod" name="doccatcod" class="form-control" required></select>
+                                                </div>
+                                                <div class="form-group mb-2">
+                                                    <label>Valor:</label>
+                                                    <input type="text" id="edit_docv" name="docv" class="form-control" required>
+                                                </div>
+                                                <div class="form-group mb-2">
+                                                    <label>Observações</label>
+                                                    <textarea id="edit_docobs" name="docobs" rows="2" class="form-control"></textarea>
+                                                </div>
+                                                <div class="form-group mb-2">
+                                                    <label>Status</label>
+                                                    <div class="form-check">
+                                                        <input class="form-check-input" type="checkbox" id="edit_docsta" name="docsta" value="BA">
+                                                        <label class="form-check-label" for="edit_docsta">Recebido</label>
+                                                    </div>
+                                                    <input type="date" id="edit_docdtpag" name="docdtpag" class="form-control mt-2" required>
+                                                </div>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                                                <button type="submit" class="btn btn-primary">Salvar</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <!-- criar uma table para mostrar os lançamentos -->
                     </div>

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -21,23 +21,24 @@ document.addEventListener("DOMContentLoaded", function () {
         }
         const docsta = dado.docsta === "LA" ? "Pendente" : "Recebido";
         const dataFormatada = dado.docdtpag
-          ? dado.docdtpag.split("T")[0] 
+          ? dado.docdtpag.split("T")[0]
           : null;
         const partes = dataFormatada.split("-");
         const dataFormatada1 = `${partes[2]}-${partes[1]}-${partes[0]}`;
         tr.innerHTML = `
-            <td>${dataFormatada1}</td> 
+            <td>${dataFormatada1}</td>
             <td>${dado.docv}</td>
             <td>${dado.tcdes}</td>
             <td>${dado.natdes}</td>
             <td>${dado.catdes}</td>
             <td>${dado.contades}</td>
-            <td>${dado.docobs}</td> 
+            <td>${dado.docobs}</td>
             <td>
                 ${dado.docsta === "LA" ? '<i class="fa fa-spinner fa-spin fa-1x fa-fw"></i>' : '<i class="fa fa-check-square"></i>'}
                 ${docsta}
-            </td>                    
+            </td>
             <td>
+                <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})">Editar</button>
                 <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})">Deletar</button>
             </td>
               `;
@@ -248,6 +249,92 @@ document.addEventListener("DOMContentLoaded", function () {
       });
     })
     .catch((error) => {
-      console.error("Erro ao carregar categorias:", error);
+  console.error("Erro ao carregar categorias:", error);
+  });
+});
+
+// Carregar opções nos selects do modal de edição
+document.addEventListener("DOMContentLoaded", function () {
+  fetch('/api/dadosUserLogado')
+    .then(res => res.json())
+    .then(dados => fetch(`${BASE_URL}/tc/${dados.usucod}`))
+    .then(res => res.json())
+    .then(data => {
+      const select = document.getElementById('edit_tccod');
+      data.forEach(item => {
+        const opt = document.createElement('option');
+        opt.value = item.tccod;
+        opt.textContent = item.tcdes;
+        select.appendChild(opt);
+      });
     });
+  fetch('/api/dadosUserLogado')
+    .then(res => res.json())
+    .then(dados => fetch(`${BASE_URL}/contas/${dados.usucod}`))
+    .then(res => res.json())
+    .then(data => {
+      const select = document.getElementById('edit_contacod');
+      data.forEach(item => {
+        const opt = document.createElement('option');
+        opt.value = item.contacod;
+        opt.textContent = `${item.contades} (${item.contatipodes})`;
+        select.appendChild(opt);
+      });
+    });
+  fetch('/api/dadosUserLogado')
+    .then(res => res.json())
+    .then(dados => fetch(`${BASE_URL}/catTodosReceita/${dados.usucod}`))
+    .then(res => res.json())
+    .then(data => {
+      const select = document.getElementById('edit_catcod');
+      data.forEach(item => {
+        const opt = document.createElement('option');
+        opt.value = item.catcod;
+        opt.textContent = item.catdes;
+        select.appendChild(opt);
+      });
+    });
+});
+
+// Abrir modal de edição preenchendo dados
+window.abrirEditar = async function(id) {
+  try {
+    const res = await fetch(`${BASE_URL}/docid/${id}`);
+    if(!res.ok) throw new Error();
+    const doc = await res.json();
+    document.getElementById('edit_doccod').value = doc.doccod;
+    document.getElementById('edit_docv').value = doc.docv;
+    document.getElementById('edit_docobs').value = doc.docobs || '';
+    document.getElementById('edit_docdtpag').value = doc.docdtpag ? doc.docdtpag.split('T')[0] : '';
+    document.getElementById('edit_docsta').checked = doc.docsta === 'BA';
+    document.getElementById('edit_contacod').value = doc.doccontacod;
+    document.getElementById('edit_tccod').value = doc.doctccod;
+    document.getElementById('edit_catcod').value = doc.doccatcod;
+    const modal = new bootstrap.Modal(document.getElementById('modalEditar'));
+    modal.show();
+  } catch (err) {
+    alert('Erro ao carregar dados.');
+    console.error(err);
+  }
+};
+
+// Submissão do formulário de edição
+document.getElementById('formEditar').addEventListener('submit', function(e){
+  e.preventDefault();
+  const form = e.target;
+  const data = Object.fromEntries(new FormData(form).entries());
+  if(!data.docsta) data.docsta = 'LA';
+  fetch(`${BASE_URL}/docedit/${data.doccod}`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type':'application/json' },
+    body: JSON.stringify(data)
+  })
+  .then(res => res.json())
+  .then(() => {
+    const modalEl = document.getElementById('modalEditar');
+    bootstrap.Modal.getInstance(modalEl).hide();
+    atualizarTabelaReceitas();
+  })
+  .catch(err => { alert('Erro ao editar registro.'); console.error(err); });
 });

--- a/routes/docRoutes.js
+++ b/routes/docRoutes.js
@@ -11,6 +11,8 @@ router.get('/doc/receitas',autenticarToken, docController.listarDocsReceitas);
 router.get('/doc/despesas',autenticarToken, docController.listarDocsDespesas);
 router.get('/doc/despesas/:id',autenticarToken, docController.listarDocsDespesasUser);
 router.get('/doc/receitas/:id',autenticarToken, docController.listarDocsReceitasUser);
+router.get('/docid/:id',autenticarToken, docController.listarDocId);
+router.put('/docedit/:id',autenticarToken, docController.editarDoc);
 router.put('/doc/:id',autenticarToken, docController.deletarDoc);
 router.delete('/doc',autenticarToken, docController.deletarTodos);
 


### PR DESCRIPTION
## Summary
- allow fetching individual docs and update them
- expose new routes for doc editing
- add edit modal in the receita launch page
- implement JS to handle editing in-place

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846159875c8832c97a62ea328a1020f