### PR TITLE
Add receive/pay actions with edit modal

### DIFF
--- a/public/html/lancamento_despesa.html
+++ b/public/html/lancamento_despesa.html
@@ -149,14 +149,62 @@
                                             <th>Ações</th>
                                         </tr>
                                     </thead>
-                                    <tbody id="corpoTabela">
-                                    </tbody>
-                                </table>
-                            </div>
-
+                                <tbody id="corpoTabela">
+                                </tbody>
+                            </table>
                         </div>
+                        <!-- Modal de edição -->
+                        <div class="modal fade" id="modalEditar" tabindex="-1" aria-labelledby="modalEditarLabel" aria-hidden="true">
+                            <div class="modal-dialog">
+                                <div class="modal-content">
+                                    <form id="formEditar">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title" id="modalEditarLabel">Editar Lançamento</h5>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <input type="hidden" id="edit_doccod" name="doccod">
+                                            <div class="form-group mb-2">
+                                                <label>Conta:</label>
+                                                <select id="edit_contacod" name="doccontacod" class="form-control" required></select>
+                                            </div>
+                                            <div class="form-group mb-2">
+                                                <label>Tipo de Cobrança:</label>
+                                                <select id="edit_tccod" name="doctccod" class="form-control" required></select>
+                                            </div>
+                                            <div class="form-group mb-2">
+                                                <label>Categoria:</label>
+                                                <select id="edit_catcod" name="doccatcod" class="form-control" required></select>
+                                            </div>
+                                            <div class="form-group mb-2">
+                                                <label>Valor:</label>
+                                                <input type="text" id="edit_docv" name="docv" class="form-control" required>
+                                            </div>
+                                            <div class="form-group mb-2">
+                                                <label>Observações</label>
+                                                <textarea id="edit_docobs" name="docobs" rows="2" class="form-control"></textarea>
+                                            </div>
+                                            <div class="form-group mb-2">
+                                                <label>Status</label>
+                                                <div class="form-check">
+                                                    <input class="form-check-input" type="checkbox" id="edit_docsta" name="docsta" value="BA">
+                                                    <label class="form-check-label" for="edit_docsta">Pago</label>
+                                                </div>
+                                                <input type="date" id="edit_docdtpag" name="docdtpag" class="form-control mt-2" required>
+                                            </div>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                                            <button type="submit" class="btn btn-primary">Salvar</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+
                     </div>
                 </div>
+            </div>
 
             </main>
         </div>

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -38,6 +38,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 ${docsta}
             </td>
             <td>
+                ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarRecebido(${dado.doccod})">Recebido</button>` : ''}
                 <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})">Editar</button>
                 <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})">Deletar</button>
             </td>
@@ -157,6 +158,8 @@ async function atualizarTabelaReceitas() {
           ${docsta}
         </td>
         <td>
+          ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarRecebido(${dado.doccod})">Recebido</button>` : ''}
+          <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})">Editar</button>
           <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})">Deletar</button>
         </td>
       `;
@@ -338,3 +341,15 @@ document.getElementById('formEditar').addEventListener('submit', function(e){
   })
   .catch(err => { alert('Erro ao editar registro.'); console.error(err); });
 });
+
+// Marca lançamento como recebido
+window.marcarRecebido = function(id) {
+  fetch(`${BASE_URL}/docstatus/${id}`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' }
+  })
+  .then(res => res.json())
+  .then(() => atualizarTabelaReceitas())
+  .catch(err => { alert('Erro ao atualizar status.'); console.error(err); });
+};

--- a/routes/docRoutes.js
+++ b/routes/docRoutes.js
@@ -13,6 +13,7 @@ router.get('/doc/despesas/:id',autenticarToken, docController.listarDocsDespesas
 router.get('/doc/receitas/:id',autenticarToken, docController.listarDocsReceitasUser);
 router.get('/docid/:id',autenticarToken, docController.listarDocId);
 router.put('/docedit/:id',autenticarToken, docController.editarDoc);
+router.put('/docstatus/:id',autenticarToken, docController.atualizarStatus);
 router.put('/doc/:id',autenticarToken, docController.deletarDoc);
 router.delete('/doc',autenticarToken, docController.deletarTodos);
 


### PR DESCRIPTION
## Summary
- add controller logic to mark document status and update account balance
- expose new `/docstatus/:id` route
- create edit modal on despesas page
- add pay/receive buttons and editing features for receitas and despesas

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68461897eabc832caf5a31fcd3412507