### PR TITLE
Fix account edit form handling

### DIFF
--- a/public/html/editar.html
+++ b/public/html/editar.html
@@ -79,7 +79,8 @@
                                     <div class="container d-flex justify-content-center">
                                         <div class="w-100" style="max-width: 600px;">
                                             <form id="meuFormulario" class="form-inline">
-                                                <input id="usucod" name="contausucod" type="hidden" value="" />    
+                                                <input id="usucod" name="contausucod" type="hidden" value="" />
+                                                <input id="contacod" name="contacod" type="hidden" value="" />
                                                 <div class="form-group">
                                                     <label>Saldo da conta:</label>
                                                     <input type="number" name="contavltotal" class="form-control"

--- a/public/js/conta.js
+++ b/public/js/conta.js
@@ -8,6 +8,7 @@ document.addEventListener("DOMContentLoaded", function () {
     .then(res => res.json())
     .then(dados => {
         const corpoTabela = document.getElementById("corpoTabela");
+        if (!corpoTabela) return; // Se não existir tabela, nada a fazer
         corpoTabela.innerHTML = ""; // Limpa o conteúdo atual da tabela
 
         dados.forEach(dado => {
@@ -107,6 +108,7 @@ function atualizarTabela() {
     .then(res => res.json())
     .then(dados => {
       const corpoTabela = document.getElementById("corpoTabela");
+      if (!corpoTabela) return;
       corpoTabela.innerHTML = "";
       dados.forEach(dado => {
         const tr = document.createElement("tr");

--- a/public/js/usucod.js
+++ b/public/js/usucod.js
@@ -1,14 +1,13 @@
-      window.onload = function () {
-        fetch('/api/dadosUserLogado', {
-            credentials: 'include' 
-        })
-        .then(response => response.json())
-        .then(data => {
-            const usucod = data.usucod;
-            
-            document.getElementById("usucod").value = usucod;
-        })
-        .catch(error => {
-            console.error('Erro ao buscar codigoUser:', error);
-        });
-        };
+window.onload = function () {
+  fetch('/api/dadosUserLogado', {
+    credentials: 'include'
+  })
+    .then(response => response.json())
+    .then(data => {
+      const usucod = data.usucod;
+      document.getElementById('usucod').value = usucod;
+    })
+    .catch(error => {
+      console.error('Erro ao buscar codigoUser:', error);
+    });
+};


### PR DESCRIPTION
## Summary
- allow editing script to run on pages without table
- expose hidden `contacod` field in edit page so PUT is used
- clean corrupted text in `usucod.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68461cea3790832ca9fdf011a21ee524