### PR TITLE
Implement grid improvements for lançamentos

### DIFF
--- a/public/html/lancamento_despesa.html
+++ b/public/html/lancamento_despesa.html
@@ -69,7 +69,11 @@
                     <div class="card">
                         <div class="card-body">
 
-                            <div class="d-flex justify-content-center">
+                            <div class="d-flex justify-content-between mb-3">
+                                <button id="novoLancamento" class="btn btn-primary">Novo</button>
+                                <input id="buscaLancamento" class="form-control" style="max-width:200px;" placeholder="Buscar">
+                            </div>
+                            <div id="formContainer" style="display:none;" class="d-flex justify-content-center">
                                 <div class="w-100" style="max-width: 400px;">
                                     <h3>Novo lançamento</h3>
                                     <form id="meuFormulario">

--- a/public/html/lancamento_receita.html
+++ b/public/html/lancamento_receita.html
@@ -66,7 +66,11 @@
                 <div class="container">
                     <div class="card">
                         <div class="card-body">
-                            <div class="container d-flex justify-content-center">
+                            <div class="d-flex justify-content-between mb-3">
+                                <button id="novoLancamento" class="btn btn-primary">Novo</button>
+                                <input id="buscaLancamento" class="form-control" style="max-width: 200px;" placeholder="Buscar">
+                            </div>
+                            <div id="formContainer" style="display:none;" class="container d-flex justify-content-center">
                                 <div class="w-100" style="max-width: 400px;">
                                     <h3>Novo lançamento</h3>
                                     <form id="meuFormulario">
@@ -132,7 +136,7 @@
                                 </div>
                             </div>
 
-                            <h3>Novo lançamento</h3>
+                            <h3>Lançamentos Registrados</h3>
                             <div class="table-responsive">
                                 <table class="table table-lg table-striped table-hover table-bordered modern-table">
                                     <thead>

--- a/public/js/lancamentos_despesa.js
+++ b/public/js/lancamentos_despesa.js
@@ -35,9 +35,9 @@ document.addEventListener("DOMContentLoaded", function () {
                             ${docsta}
                         </td>
                         <td>
-                            ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarPago(${dado.doccod})">Pago</button>` : ''}
-                            <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})">Editar</button>
-                            <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})">Deletar</button>
+                            ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarPago(${dado.doccod})" title="Pago"><i class="fa fa-check"></i></button>` : ''}
+                            <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})" title="Editar"><i class="fa fa-edit"></i></button>
+                            <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})" title="Deletar"><i class="fa fa-trash"></i></button>
                         </td>
                     `;
         corpoTabela.appendChild(tr);
@@ -155,9 +155,9 @@ async function atualizarTabelaDespesas() {
           ${docsta}
         </td>
         <td>
-          ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarPago(${dado.doccod})">Pago</button>` : ''}
-          <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})">Editar</button>
-          <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})">Deletar</button>
+          ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarPago(${dado.doccod})" title="Pago"><i class="fa fa-check"></i></button>` : ''}
+          <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})" title="Editar"><i class="fa fa-edit"></i></button>
+          <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})" title="Deletar"><i class="fa fa-trash"></i></button>
         </td>
       `;
       corpoTabela.appendChild(tr);
@@ -349,3 +349,21 @@ window.marcarPago = function(id) {
   .then(() => atualizarTabelaDespesas())
   .catch(err => { alert('Erro ao atualizar status.'); console.error(err); });
 };
+
+// Toggle do formulário e busca no grid
+document.addEventListener('DOMContentLoaded', () => {
+  const btnNovo = document.getElementById('novoLancamento');
+  const formContainer = document.getElementById('formContainer');
+  btnNovo?.addEventListener('click', () => {
+    if(formContainer){
+      formContainer.style.display = formContainer.style.display === 'none' ? 'block' : 'none';
+    }
+  });
+  const busca = document.getElementById('buscaLancamento');
+  busca?.addEventListener('input', () => {
+    const termo = busca.value.toLowerCase();
+    document.querySelectorAll('#corpoTabela tr').forEach(tr => {
+      tr.style.display = tr.textContent.toLowerCase().includes(termo) ? '' : 'none';
+    });
+  });
+});

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -38,9 +38,9 @@ document.addEventListener("DOMContentLoaded", function () {
                 ${docsta}
             </td>
             <td>
-                ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarRecebido(${dado.doccod})">Recebido</button>` : ''}
-                <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})">Editar</button>
-                <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})">Deletar</button>
+                ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarRecebido(${dado.doccod})" title="Recebido"><i class="fa fa-check"></i></button>` : ''}
+                <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})" title="Editar"><i class="fa fa-edit"></i></button>
+                <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})" title="Deletar"><i class="fa fa-trash"></i></button>
             </td>
               `;
         corpoTabela.appendChild(tr);
@@ -158,9 +158,9 @@ async function atualizarTabelaReceitas() {
           ${docsta}
         </td>
         <td>
-          ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarRecebido(${dado.doccod})">Recebido</button>` : ''}
-          <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})">Editar</button>
-          <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})">Deletar</button>
+          ${dado.docsta === "LA" ? `<button class="btn btn-success btn-sm" onclick="marcarRecebido(${dado.doccod})" title="Recebido"><i class="fa fa-check"></i></button>` : ''}
+          <button class="btn btn-warning btn-sm" onclick="abrirEditar(${dado.doccod})" title="Editar"><i class="fa fa-edit"></i></button>
+          <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})" title="Deletar"><i class="fa fa-trash"></i></button>
         </td>
       `;
       corpoTabela.appendChild(tr);
@@ -353,3 +353,21 @@ window.marcarRecebido = function(id) {
   .then(() => atualizarTabelaReceitas())
   .catch(err => { alert('Erro ao atualizar status.'); console.error(err); });
 };
+
+// Toggle do formulário e busca no grid
+document.addEventListener('DOMContentLoaded', () => {
+  const btnNovo = document.getElementById('novoLancamento');
+  const formContainer = document.getElementById('formContainer');
+  btnNovo?.addEventListener('click', () => {
+    if(formContainer){
+      formContainer.style.display = formContainer.style.display === 'none' ? 'block' : 'none';
+    }
+  });
+  const busca = document.getElementById('buscaLancamento');
+  busca?.addEventListener('input', () => {
+    const termo = busca.value.toLowerCase();
+    document.querySelectorAll('#corpoTabela tr').forEach(tr => {
+      tr.style.display = tr.textContent.toLowerCase().includes(termo) ? '' : 'none';
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- show only the table on lançamento pages and add button to open form
- filter grid contents with a search box
- replace action buttons with icons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684622e442c0832c8217202168c9ec26