### PR TITLE
Adjust launch screens

### DIFF
--- a/public/html/lancamento_despesa.html
+++ b/public/html/lancamento_despesa.html
@@ -71,7 +71,6 @@
 
                             <div class="d-flex justify-content-between mb-3">
                                 <button id="novoLancamento" class="btn btn-primary">Novo</button>
-                                <input id="buscaLancamento" class="form-control" style="max-width:200px;" placeholder="Buscar">
                             </div>
                             <div id="formContainer" style="display:none;" class="d-flex justify-content-center">
                                 <div class="w-100" style="max-width: 400px;">
@@ -137,6 +136,7 @@
                                 </div>
                             </div>
 
+                            <input id="buscaLancamento" class="form-control mb-3" style="max-width:200px;" placeholder="Buscar">
                             <h3 class="mt-5">Lançamentos Registrados</h3>
                             <div class="table-responsive">
                                 <table class="table table-lg table-striped table-hover table-bordered modern-table">

--- a/public/html/lancamento_receita.html
+++ b/public/html/lancamento_receita.html
@@ -68,7 +68,6 @@
                         <div class="card-body">
                             <div class="d-flex justify-content-between mb-3">
                                 <button id="novoLancamento" class="btn btn-primary">Novo</button>
-                                <input id="buscaLancamento" class="form-control" style="max-width: 200px;" placeholder="Buscar">
                             </div>
                             <div id="formContainer" style="display:none;" class="container d-flex justify-content-center">
                                 <div class="w-100" style="max-width: 400px;">
@@ -136,6 +135,7 @@
                                 </div>
                             </div>
 
+                            <input id="buscaLancamento" class="form-control mb-3" style="max-width: 200px;" placeholder="Buscar">
                             <h3>Lançamentos Registrados</h3>
                             <div class="table-responsive">
                                 <table class="table table-lg table-striped table-hover table-bordered modern-table">


### PR DESCRIPTION
## Summary
- show the launch form only after clicking **Novo**
- move search input above the listing table

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684625170074832cb23028467d3577b8