### PR TITLE
Atualizar formulários para usar modais

### DIFF
--- a/public/html/lancamento_despesa.html
+++ b/public/html/lancamento_despesa.html
@@ -72,70 +72,6 @@
                             <div class="d-flex justify-content-between mb-3">
                                 <button id="novoLancamento" class="btn btn-primary">Novo</button>
                             </div>
-                            <div id="formContainer" style="display:none;" class="d-flex justify-content-center">
-                                <div class="w-100" style="max-width: 400px;">
-                                    <h3>Novo lançamento</h3>
-                                    <form id="meuFormulario">
-                                        <input id="usucod" name="docusucod" type="hidden" value="" />
-
-                                        <div class="form-group">
-                                            <label>Conta:</label>
-                                            <select id="contacod" name="doccontacod" class="form-control" required>
-                                                <option value="" hidden>Selecione</option>
-                                            </select>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <label>Tipo de Cobrança:</label>
-                                            <select id="tipoCobranca" name="doctccod" class="form-control" required>
-                                                <option value="" hidden>Selecione</option>
-                                            </select>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <label>Categoria:</label>
-                                            <select id="categoria" name="doccatcod" class="form-control" required>
-                                                <option value="" hidden>Selecione</option>
-                                            </select>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <label>Valor:</label>
-                                            <input type="text" name="docv" class="form-control" required
-                                                placeholder="R$ 0,00">
-                                        </div>
-
-                                        <div class="form-group">
-                                            <label>Observações (opcional):</label>
-                                            <textarea name="docobs" rows="3" class="form-control"
-                                                placeholder="Informações complementares"></textarea>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <label>Status</label>
-                                            <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" name="docsta"
-                                                    value="BA">
-                                                <label class="form-check-label" for="status">Pago</label>
-                                            </div>
-                                            <div class="form-group">
-
-                                                <input id="docdtpag" type="date" name="docdtpag" class="form-control"
-                                                    required>
-                                            </div>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <button class="btn btn-success" type="submit">Salvar</button>
-                                        </div>
-
-                                        <br>
-                                        <div class="alert alert-success" id="alerta-sucess" style="display: none;">
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-
                             <input id="buscaLancamento" class="form-control mb-3" style="max-width:200px;" placeholder="Buscar">
                             <h3 class="mt-5">Lançamentos Registrados</h3>
                             <div class="table-responsive">
@@ -200,6 +136,63 @@
                                         <div class="modal-footer">
                                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                                             <button type="submit" class="btn btn-primary">Salvar</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Modal de novo lançamento -->
+                        <div class="modal fade" id="modalNovo" tabindex="-1" aria-labelledby="modalNovoLabel" aria-hidden="true">
+                            <div class="modal-dialog">
+                                <div class="modal-content">
+                                    <form id="meuFormulario">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title" id="modalNovoLabel">Novo Lançamento</h5>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <input id="usucod" name="docusucod" type="hidden" value="" />
+                                            <div class="form-group">
+                                                <label>Conta:</label>
+                                                <select id="contacod" name="doccontacod" class="form-control" required>
+                                                    <option value="" hidden>Selecione</option>
+                                                </select>
+                                            </div>
+                                            <div class="form-group">
+                                                <label>Tipo de Cobrança:</label>
+                                                <select id="tipoCobranca" name="doctccod" class="form-control" required>
+                                                    <option value="" hidden>Selecione</option>
+                                                </select>
+                                            </div>
+                                            <div class="form-group">
+                                                <label>Categoria:</label>
+                                                <select id="categoria" name="doccatcod" class="form-control" required>
+                                                    <option value="" hidden>Selecione</option>
+                                                </select>
+                                            </div>
+                                            <div class="form-group">
+                                                <label>Valor:</label>
+                                                <input type="text" name="docv" class="form-control" required placeholder="R$ 0,00">
+                                            </div>
+                                            <div class="form-group">
+                                                <label>Observações (opcional):</label>
+                                                <textarea name="docobs" rows="3" class="form-control" placeholder="Informações complementares"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label>Status</label>
+                                                <div class="form-check">
+                                                    <input class="form-check-input" type="checkbox" name="docsta" value="BA">
+                                                    <label class="form-check-label" for="status">Pago</label>
+                                                </div>
+                                                <div class="form-group">
+                                                    <input id="docdtpag" type="date" name="docdtpag" class="form-control" required>
+                                                </div>
+                                            </div>
+                                            <div class="alert alert-success mt-2" id="alerta-sucess" style="display: none;"></div>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                                            <button class="btn btn-success" type="submit">Salvar</button>
                                         </div>
                                     </form>
                                 </div>

--- a/public/html/lancamento_receita.html
+++ b/public/html/lancamento_receita.html
@@ -69,72 +69,6 @@
                             <div class="d-flex justify-content-between mb-3">
                                 <button id="novoLancamento" class="btn btn-primary">Novo</button>
                             </div>
-                            <div id="formContainer" style="display:none;" class="container d-flex justify-content-center">
-                                <div class="w-100" style="max-width: 400px;">
-                                    <h3>Novo lançamento</h3>
-                                    <form id="meuFormulario">
-                                        <input id="usucod" type="hidden" name="docusucod" value="">
-                                        <input id="docdtlan" type="hidden" name="docdtlan" value="">
-
-                                        <div class="form-group">
-                                            <label>Conta:</label>
-                                            <select id="contacod" name="doccontacod" class="form-control" required>
-                                                <option value="" hidden>Selecione</option>
-                                            </select>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <label>Tipo de Cobrança:</label>
-                                            <select id="tipoCobranca" name="doctccod" class="form-control" required>
-                                                <option value="" hidden>Selecione</option>
-                                            </select>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <label>Categoria:</label>
-                                            <select id="categoria" name="doccatcod" class="form-control" required>
-                                                <option value="" hidden>Selecione</option>
-                                            </select>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <label>Valor:</label>
-                                            <input id="docv" type="text" name="docv" class="form-control" required
-                                                placeholder="R$ 0,00">
-                                        </div>
-
-
-                                        <div class="form-group">
-                                            <label>Observações (opcional):</label>
-                                            <textarea name="docobs" rows="2" class="form-control"
-                                                placeholder="Informações complementares"></textarea>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <label>Status</label>
-                                            <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" name="docsta"
-                                                    value="BA">
-                                                <label class="form-check-label" for="status">Recebido</label>
-                                            </div>
-                                            <div class="form-group">
-
-                                                <input id="docdtpag" type="date" name="docdtpag" class="form-control"
-                                                    required>
-                                            </div>
-                                        </div>
-
-                                        <div class="form-group">
-                                            <button class="btn btn-success" type="submit">Salvar</button>
-                                        </div>
-
-                                        <br>
-                                        <div class="alert alert-success" id="alerta-sucess" style="display: none;">
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-
                             <input id="buscaLancamento" class="form-control mb-3" style="max-width: 200px;" placeholder="Buscar">
                             <h3>Lançamentos Registrados</h3>
                             <div class="table-responsive">
@@ -204,7 +138,65 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
+                            </div>
+                            <!-- Modal de novo lançamento -->
+                            <div class="modal fade" id="modalNovo" tabindex="-1" aria-labelledby="modalNovoLabel" aria-hidden="true">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                        <form id="meuFormulario">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title" id="modalNovoLabel">Novo Lançamento</h5>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                            </div>
+                                            <div class="modal-body">
+                                                <input id="usucod" type="hidden" name="docusucod" value="">
+                                                <input id="docdtlan" type="hidden" name="docdtlan" value="">
+                                                <div class="form-group">
+                                                    <label>Conta:</label>
+                                                    <select id="contacod" name="doccontacod" class="form-control" required>
+                                                        <option value="" hidden>Selecione</option>
+                                                    </select>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Tipo de Cobrança:</label>
+                                                    <select id="tipoCobranca" name="doctccod" class="form-control" required>
+                                                        <option value="" hidden>Selecione</option>
+                                                    </select>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Categoria:</label>
+                                                    <select id="categoria" name="doccatcod" class="form-control" required>
+                                                        <option value="" hidden>Selecione</option>
+                                                    </select>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Valor:</label>
+                                                    <input id="docv" type="text" name="docv" class="form-control" required placeholder="R$ 0,00">
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Observações (opcional):</label>
+                                                    <textarea name="docobs" rows="2" class="form-control" placeholder="Informações complementares"></textarea>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Status</label>
+                                                    <div class="form-check">
+                                                        <input class="form-check-input" type="checkbox" name="docsta" value="BA">
+                                                        <label class="form-check-label" for="status">Recebido</label>
+                                                    </div>
+                                                    <div class="form-group">
+                                                        <input id="docdtpag" type="date" name="docdtpag" class="form-control" required>
+                                                    </div>
+                                                </div>
+                                                <div class="alert alert-success mt-2" id="alerta-sucess" style="display: none;"></div>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                                                <button class="btn btn-success" type="submit">Salvar</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
                         <!-- criar uma table para mostrar os lançamentos -->
                     </div>
                 </div>

--- a/public/js/lancamentos_despesa.js
+++ b/public/js/lancamentos_despesa.js
@@ -353,11 +353,10 @@ window.marcarPago = function(id) {
 // Toggle do formulário e busca no grid
 document.addEventListener('DOMContentLoaded', () => {
   const btnNovo = document.getElementById('novoLancamento');
-  const formContainer = document.getElementById('formContainer');
+  const modalEl = document.getElementById('modalNovo');
+  const modalNovo = modalEl ? new bootstrap.Modal(modalEl) : null;
   btnNovo?.addEventListener('click', () => {
-    if(formContainer){
-      formContainer.style.display = formContainer.style.display === 'none' ? 'block' : 'none';
-    }
+    modalNovo?.show();
   });
   const busca = document.getElementById('buscaLancamento');
   busca?.addEventListener('input', () => {

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -357,11 +357,10 @@ window.marcarRecebido = function(id) {
 // Toggle do formulário e busca no grid
 document.addEventListener('DOMContentLoaded', () => {
   const btnNovo = document.getElementById('novoLancamento');
-  const formContainer = document.getElementById('formContainer');
+  const modalEl = document.getElementById('modalNovo');
+  const modalNovo = modalEl ? new bootstrap.Modal(modalEl) : null;
   btnNovo?.addEventListener('click', () => {
-    if(formContainer){
-      formContainer.style.display = formContainer.style.display === 'none' ? 'block' : 'none';
-    }
+    modalNovo?.show();
   });
   const busca = document.getElementById('buscaLancamento');
   busca?.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- esconder formulários de despesa e receita da tela principal
- exibir os formulários em modais ao clicar no botão **Novo**

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684626855c30832c9865ad581a207865