### PR TITLE
Add extra charts and simplify dashboard

### DIFF
--- a/public/css/dashboard-theme.css
+++ b/public/css/dashboard-theme.css
@@ -60,3 +60,15 @@ form.form-inline .form-group {
         margin-bottom: 1rem;
     }
 }
+
+/* Minimal dashboard styles */
+.card.shadow-sm {
+    border: 1px solid #e5e7eb;
+    background-color: #f9fafb;
+}
+.chart-card {
+    border: 1px solid #e5e7eb;
+    background-color: #ffffff;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}

--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -66,33 +66,33 @@
                     </ol>
                     <div class="row">
                         <div class="col-xl-3 col-md-6">
-                            <div class="card modern-card bg-primary text-white mb-4">
+                            <div class="card shadow-sm mb-4">
                                 <div class="card-body">Extrato de movimentação</div>
                                 <div class="card-footer d-flex align-items-center justify-content-between">
-                                    <a class="small text-white stretched-link" href="listar_registros">Ver mais</a>
-                                    <div class="small text-white">
+                                    <a class="small stretched-link" href="listar_registros">Ver mais</a>
+                                    <div class="small">
                                         <i class="fas fa-angle-right"></i>
                                     </div>
                                 </div>
                             </div>
                         </div>
                         <div class="col-xl-3 col-md-6">
-                            <div class="card modern-card bg-success text-white mb-4">
+                            <div class="card shadow-sm mb-4">
                                 <div class="card-body">Suas Cobranças</div>
                                 <div class="card-footer d-flex align-items-center justify-content-between">
-                                    <a class="small text-white stretched-link" href="cobranca">Ver mais</a>
-                                    <div class="small text-white">
+                                    <a class="small stretched-link" href="cobranca">Ver mais</a>
+                                    <div class="small">
                                         <i class="fas fa-angle-right"></i>
                                     </div>
                                 </div>
                             </div>
                         </div>
                         <div class="col-xl-3 col-md-6">
-                            <div class="card modern-card bg-danger text-white mb-4">
+                            <div class="card shadow-sm mb-4">
                                 <div class="card-body">Saldo: R$<span id="saldo">0.00</span> </div>
                                 <div class="card-footer d-flex align-items-center justify-content-between">
-                                    <a class="small text-white stretched-link" href="contas">Ver mais</a>
-                                    <div class="small text-white">
+                                    <a class="small stretched-link" href="contas">Ver mais</a>
+                                    <div class="small">
                                         <i class="fas fa-angle-right"></i>
                                     </div>
                                 </div>
@@ -108,7 +108,6 @@
                                 </div>
                                 <div class="card-body"><canvas id="myPieChartRec" width="100%" height="50"></canvas>
                                 </div>
-                                <div class="card-footer small text-muted">Updated yesterday at 11:59 PM</div>
                             </div>
                         </div>
                         <div class="col-xl-6">
@@ -119,34 +118,27 @@
                                 </div>
                                 <div class="card-body"><canvas id="myPieChartDep" width="100%" height="50"></canvas>
                                 </div>
-                                <div class="card-footer small text-muted">Updated yesterday at 11:59 PM</div>
                             </div>
                         </div>
                     </div>
-                    <div class="col-lg-6">
-
-                    </div>
-
-                    <!--Tabela-->
-                    <div class="card mb-4">
-                        <div class="card-header">
-                            <i class="fas fa-table me-1"></i>
-                            DataTable Example
+                    <div class="row">
+                        <div class="col-xl-6">
+                            <div class="card chart-card mb-4">
+                                <div class="card-header">
+                                    <i class="fas fa-chart-line me-1"></i>
+                                    Receitas vs Despesas
+                                </div>
+                                <div class="card-body"><canvas id="lineChartReceitasDespesas" width="100%" height="40"></canvas></div>
+                            </div>
                         </div>
-                        <div class="card-body">
-                            <!-- lembrar de por o id da tabel para ficar formatada -->
-                            <table id="datatablesSimple" class="table table-striped table-hover table-bordered modern-table">
-                                <thead>
-                                    <tr>
-                                        <th>Descrição</th>
-                                        <th>Categoria</th>
-                                        <th>Valor</th>
-                                        <th>Status</th>
-                                    </tr>
-                                </thead>
-                                <tbody id="corpoTableDash">
-                                </tbody>
-                            </table>
+                        <div class="col-xl-6">
+                            <div class="card chart-card mb-4">
+                                <div class="card-header">
+                                    <i class="fas fa-chart-bar me-1"></i>
+                                    Despesas por Status
+                                </div>
+                                <div class="card-body"><canvas id="barChartPvsR" width="100%" height="40"></canvas></div>
+                            </div>
                         </div>
                     </div>
             </main>
@@ -174,6 +166,8 @@
     <!-- <script src="../js/demo-charts/chart-area-demo.js"></script> -->
     <script src="../js/demo-charts/chart-pie-despesa.js"></script>
     <script src="../js/demo-charts/chart-pie-receita.js"></script>
+    <script src="../js/demo-charts/chart-line-receitas-despesas.js"></script>
+    <script src="../js/demo-charts/chart-bar-status-despesas.js"></script>
     <!--Fim-->
     <!-- <script src="../js/demo-charts/datatables-simple-demo.js"></script>Organiza a tabela -->
     <script src="../js/saldo.js"></script>

--- a/public/js/demo-charts/chart-bar-status-despesas.js
+++ b/public/js/demo-charts/chart-bar-status-despesas.js
@@ -1,0 +1,28 @@
+fetch('/api/dadosUserLogado')
+  .then(res => res.json())
+  .then(user => fetch(`${BASE_URL}/docPvsRAnual/${user.usucod}`))
+  .then(res => res.json())
+  .then(data => {
+    const totals = {};
+    data.forEach(d => {
+      totals[d.docsta] = (totals[d.docsta] || 0) + Number(d.total);
+    });
+    const labels = Object.keys(totals);
+    const valores = labels.map(l => totals[l]);
+    const ctx = document.getElementById('barChartPvsR');
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Despesas',
+          data: valores,
+          backgroundColor: '#1B6B93'
+        }]
+      },
+      options: {
+        legend: { display: false }
+      }
+    });
+  })
+  .catch(err => console.error('Erro ao carregar grafico barra:', err));

--- a/public/js/demo-charts/chart-line-receitas-despesas.js
+++ b/public/js/demo-charts/chart-line-receitas-despesas.js
@@ -1,0 +1,41 @@
+fetch('/api/dadosUserLogado')
+  .then(res => res.json())
+  .then(user => fetch(`${BASE_URL}/docAnual/${user.usucod}`))
+  .then(res => res.json())
+  .then(data => {
+    const mesesSet = new Set(data.map(d => d.mes));
+    const meses = Array.from(mesesSet).sort();
+    const receitas = meses.map(m => {
+      const item = data.find(d => d.mes === m && d.docnatcod === 2);
+      return item ? Number(item.total) : 0;
+    });
+    const despesas = meses.map(m => {
+      const item = data.find(d => d.mes === m && d.docnatcod === 1);
+      return item ? Number(item.total) : 0;
+    });
+    const ctx = document.getElementById('lineChartReceitasDespesas');
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: meses,
+        datasets: [
+          {
+            label: 'Receitas',
+            data: receitas,
+            borderColor: '#28a745',
+            fill: false
+          },
+          {
+            label: 'Despesas',
+            data: despesas,
+            borderColor: '#dc3545',
+            fill: false
+          }
+        ]
+      },
+      options: {
+        legend: { display: true }
+      }
+    });
+  })
+  .catch(err => console.error('Erro ao carregar grafico linha:', err));


### PR DESCRIPTION
## Summary
- make dashboard cards plain
- remove outdated table
- add extra line and bar charts
- style cards minimally
- load new chart scripts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68462e82eba4832ca273f27a894d4987