### PR TITLE
Add animated clock icon for session countdown

### DIFF
--- a/public/js/cronometro.js
+++ b/public/js/cronometro.js
@@ -23,7 +23,8 @@ var x = setInterval(function() {
   var seconds = Math.floor((distance % (1000 * 60)) / 1000);
     
   
-  document.getElementById("cronometro").innerHTML = "Sessão expira em: " + minutes + "m " + seconds + "s ";
+  document.getElementById("cronometro").innerHTML =
+    "<i class='fas fa-clock fa-spin'></i> " + minutes + "m " + seconds + "s";
     
   // If the count down is over, write some text 
   if (distance < 0) {


### PR DESCRIPTION
## Summary
- show a spinning clock icon for the session countdown label

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68462f48b874832cb7952b2e8e9920e8