### PR TITLE
Implement new account creation page

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,6 +115,9 @@ app.get('/cobranca', autenticarToken, (req, res) => {
 app.get('/contas', autenticarToken, (req, res) => {
   res.sendFile(__dirname + '/public/html/conta.html')
 });
+app.get('/conta_nova', autenticarToken, (req, res) => {
+  res.sendFile(__dirname + '/public/html/conta_nova.html')
+});
 app.get('/pagina_em_branco', autenticarToken, (req, res) => {
   res.sendFile(__dirname + '/public/html/pagina-branco.html')
 });

--- a/public/html/conta_nova.html
+++ b/public/html/conta_nova.html
@@ -61,7 +61,7 @@
                 <div class="row">
                     <div class="card mb-4">
                         <div class="card-header">
-                            <h3> <i class="fas fa-briefcase"></i></i><!--Aqui o nome da pagina--> Contas
+                            <h3> <i class="fas fa-briefcase"></i></i><!--Aqui o nome da pagina--> Contas - Novo
                             </h3>
                         </div>
                     </div>
@@ -76,32 +76,43 @@
 
                                 <div class="card-body">
 
-                                    <div class="d-flex justify-content-between mb-3">
-                                        <a href="conta_nova" class="btn btn-primary" id="novoConta">Novo</a>
+                                    <div class="container d-flex justify-content-center">
+                                        <div class="w-100" style="max-width: 600px;">
+                                            <form id="meuFormulario" class="form-inline">
+                                                <input id="usucod" name="contausucod" type="hidden" value="" />
+                                                <input id="contacod" name="contacod" type="hidden" value="" />
+                                                <div class="form-group">
+                                                    <label>Saldo da conta:</label>
+                                                    <input type="number" name="contavltotal" class="form-control"
+                                                        required placeholder="R$ 0,00">
+                                                    <label>Nome:</label>
+                                                    <input type="text" name="contades" class="form-control" required
+                                                        placeholder="Nome da conta">
+                                                    <label>Tipo:</label>
+                                                    <select id="tipoCobranca" name="contatipo" class="form-control"
+                                                        required>
+                                                        <option value="" hidden>Selecione</option>
+                                                        <option value="1">Dinheiro</option>
+                                                        <option value="2">Conta Corrente</option>
+                                                        <option value="3">Conta Poupança</option>
+                                                        <option value="4">Investimento</option>
+                                                        <option value="5">Outro</option>
+                                                    </select>
+
+                                                </div>
+                                                <br>
+                                                <button class="btn btn-success" type="submit">Salvar</button>
+
+                                                <br>
+                                                <div class="alert alert-success" id="alerta-sucess" style="display: none;"></div>
+                                            </form>
+                                        </div>
                                     </div>
-                                    <table class="table table-striped table-hover table-bordered modern-table">
-                                        <thead>
-                                            <tr>
-                                                <th>Conta</th>
-                                                <th>tipo</th>
-                                                <th>Saldo Total</th>
-                                                <th>Ações</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody id="corpoTabela">
-                                        </tbody>
-                                    </table>
                                 </div>
                             </div>
-
-
                         </div>
-
                     </div>
                 </div>
-
-
-
         </div>
     </div>
     </main>
@@ -121,18 +132,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/simple-datatables@7.1.2/dist/umd/simple-datatables.min.js"
-        crossorigin="anonymous"></script>
     <!--Fim Bootstrap-->
-
-    <!--Demo dos graficos começo-->
-    <!-- <script src="../../dist/assets/demo/chart-area-demo.js"></script>
-    <script src="../../dist/assets/demo/chart-pie-demo.js"></script> -->
-    <!--Fim-->
-    <!-- <script src="../../src/js/datatables-simple-demo.js"></script>Organiza a tabela -->
-
-
-
 </body>
 
 </html>

--- a/public/js/conta.js
+++ b/public/js/conta.js
@@ -52,7 +52,8 @@ document.addEventListener("DOMContentLoaded", function () {
 // });
 // post
 
-document.getElementById("meuFormulario").addEventListener("submit", function (e) {
+const formElem = document.getElementById("meuFormulario");
+if (formElem) formElem.addEventListener("submit", function (e) {
   e.preventDefault();
 
   const form = e.target;
@@ -88,13 +89,8 @@ document.getElementById("meuFormulario").addEventListener("submit", function (e)
       alerta.innerHTML = contacod ? "Editado com sucesso!" : "Lançado com sucesso!";
       setTimeout(() => {
         alerta.style.display = "none";
-      }, 2000);
-      // Se for edição, volte para a lista de contas
-      if (contacod) {
-        setTimeout(() => {
-          window.location.href = "conta.html";
-        }, 1000);
-      }
+        window.location.href = "conta.html";
+      }, 1000);
     })
     .catch(erro => {
       alert("Erro ao salvar os dados.");


### PR DESCRIPTION
## Summary
- add route for `/conta_nova`
- remove inline form from `conta.html` and add "Novo" button
- create new `conta_nova.html` for account creation
- update account JS to handle form presence and always redirect after save

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684630fcb170832cacf2a92ae7a3f3ca