### PR TITLE
Switch pie charts to doughnut charts

### DIFF
--- a/public/js/demo-charts/chart-pie-despesa.js
+++ b/public/js/demo-charts/chart-pie-despesa.js
@@ -24,7 +24,7 @@ fetch('/api/dadosUserLogado')
     });
 
     const myPieChart = new Chart(ctxDep, {
-      type: "pie",
+      type: "doughnut",
       data: {
         labels: labels,
         datasets: [
@@ -48,6 +48,7 @@ fetch('/api/dadosUserLogado')
           display: true,
           position: "top",
         },
+        cutoutPercentage: 60,
       },
     });
   })

--- a/public/js/demo-charts/chart-pie-receita.js
+++ b/public/js/demo-charts/chart-pie-receita.js
@@ -24,7 +24,7 @@ fetch('/api/dadosUserLogado')
     });
 
     const myPieChart = new Chart(ctxRec, {
-      type: "pie",
+      type: "doughnut",
       data: {
         labels: labels,
         datasets: [
@@ -48,6 +48,7 @@ fetch('/api/dadosUserLogado')
           display: true,
           position: "top",
         },
+        cutoutPercentage: 60,
       },
     });
   })


### PR DESCRIPTION
## Summary
- update expense and revenue chart scripts to render doughnut charts instead of pie charts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68463309df24832c81e1a828ef5b14a1