### PR TITLE
Add transfer card to dashboard

### DIFF
--- a/public/css/dashboard-theme.css
+++ b/public/css/dashboard-theme.css
@@ -77,6 +77,9 @@ form.form-inline .form-group {
 .dashboard-card.card-purple {
     background: linear-gradient(135deg, #d16ba5, #86a8e7);
 }
+.dashboard-card.card-orange {
+    background: linear-gradient(135deg, var(--bs-orange), var(--bs-yellow));
+}
 .dashboard-card .card-footer {
     background: transparent;
     border-top: none;

--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -98,6 +98,17 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-xl-3 col-md-6">
+                            <div class="card dashboard-card card-orange mb-4">
+                                <div class="card-body">Transferências</div>
+                                <div class="card-footer d-flex align-items-center justify-content-between">
+                                    <a class="small stretched-link" href="transf">Ver mais</a>
+                                    <div class="small">
+                                        <i class="fas fa-angle-right"></i>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="row">
                         <div class="col-xl-6">


### PR DESCRIPTION
## Summary
- add orange dashboard card for transfers linking to transfers page
- define card-orange style in dashboard-theme.css

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684631e44370832caed6cffe74f2d5b4