### PR TITLE
Update dashboard cards and chart colors

### DIFF
--- a/public/css/dashboard-theme.css
+++ b/public/css/dashboard-theme.css
@@ -80,6 +80,12 @@ form.form-inline .form-group {
 .dashboard-card.card-orange {
     background: linear-gradient(135deg, var(--bs-orange), var(--bs-yellow));
 }
+.dashboard-card.card-teal {
+    background: linear-gradient(135deg, var(--bs-teal), var(--bs-light-blue));
+}
+.dashboard-card.card-red {
+    background: linear-gradient(135deg, var(--bs-red), var(--bs-orange));
+}
 .dashboard-card .card-footer {
     background: transparent;
     border-top: none;

--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -110,6 +110,30 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row justify-content-center">
+                        <div class="col-xl-4 col-md-6">
+                            <div class="card dashboard-card card-teal mb-4">
+                                <div class="card-body">Receita</div>
+                                <div class="card-footer d-flex align-items-center justify-content-between">
+                                    <a class="small stretched-link" href="lancamento_receita">Ver mais</a>
+                                    <div class="small">
+                                        <i class="fas fa-angle-right"></i>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-xl-4 col-md-6">
+                            <div class="card dashboard-card card-red mb-4">
+                                <div class="card-body">Despesa</div>
+                                <div class="card-footer d-flex align-items-center justify-content-between">
+                                    <a class="small stretched-link" href="lancamento_despesa">Ver mais</a>
+                                    <div class="small">
+                                        <i class="fas fa-angle-right"></i>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                     <div class="row">
                         <div class="col-xl-6">
                             <div class="card chart-card mb-4">

--- a/public/js/demo-charts/chart-pie-despesa.js
+++ b/public/js/demo-charts/chart-pie-despesa.js
@@ -30,7 +30,20 @@ fetch('/api/dadosUserLogado')
         datasets: [
           {
             data: valores,
-            backgroundColor: ["#007bff", "#dc3545", "#ffc107", "#28a745", "#6f42c1", "#17a2b8", "#fd7e14", "#6610f2", "#e83e8c", "#20c997", "#343a40", "#f8f9fa"],
+            backgroundColor: [
+              "#4FC0D0",
+              "#FF6F91",
+              "#FFC75F",
+              "#00C9A7",
+              "#845EC2",
+              "#F9F871",
+              "#D65DB1",
+              "#FFC857",
+              "#2C73D2",
+              "#0081CF",
+              "#FF9671",
+              "#A2FF86",
+            ],
           },
         ],
       },

--- a/public/js/demo-charts/chart-pie-receita.js
+++ b/public/js/demo-charts/chart-pie-receita.js
@@ -30,7 +30,20 @@ fetch('/api/dadosUserLogado')
         datasets: [
           {
             data: valores,
-            backgroundColor: ["#007bff", "#dc3545", "#ffc107", "#28a745", "#6f42c1", "#17a2b8", "#fd7e14", "#6610f2", "#e83e8c", "#20c997", "#343a40", "#f8f9fa"],
+            backgroundColor: [
+              "#4FC0D0",
+              "#FF6F91",
+              "#FFC75F",
+              "#00C9A7",
+              "#845EC2",
+              "#F9F871",
+              "#D65DB1",
+              "#FFC857",
+              "#2C73D2",
+              "#0081CF",
+              "#FF9671",
+              "#A2FF86",
+            ],
           },
         ],
       },


### PR DESCRIPTION
## Summary
- add new dashboard cards for receita and despesa
- style new card colors
- enhance donut chart colors for receita and despesa

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684635458ffc832ca3c07a24dc0753e7