### PR TITLE
Fix dashboard card layout

### DIFF
--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -98,7 +98,9 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-xl-3 col-md-6">
+                    </div>
+                    <div class="row justify-content-center">
+                        <div class="col-xl-4 col-md-6">
                             <div class="card dashboard-card card-orange mb-4">
                                 <div class="card-body">Transferências</div>
                                 <div class="card-footer d-flex align-items-center justify-content-between">
@@ -109,8 +111,6 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
                         <div class="col-xl-4 col-md-6">
                             <div class="card dashboard-card card-teal mb-4">
                                 <div class="card-body">Receita</div>


### PR DESCRIPTION
## Summary
- tweak dashboard layout so that cards are arranged in two centered rows of three

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684636388140832c804bdff9f4a810c6