### PR TITLE
Fix sidebar collapse IDs

### DIFF
--- a/public/html/sidebar.html
+++ b/public/html/sidebar.html
@@ -12,8 +12,8 @@
                         Visão Geral
                     </a>
 
-                    <a class="nav-link collapsed" href="page" data-bs-toggle="collapse"
-                        data-bs-target="#collapseLayouts" aria-expanded="false" aria-controls="collapseLayouts">
+    <a class="nav-link collapsed" href="page" data-bs-toggle="collapse"
+        data-bs-target="#collapseNew" aria-expanded="false" aria-controls="collapseNew">
                         <div class="sb-nav-link-icon">
                             <i class="fas fa-edit"></i>
                         </div>
@@ -22,8 +22,8 @@
                             <i class="fas fa-angle-down"></i>
                         </div>
                     </a>
-                    <div class="collapse" id="collapseLayouts" aria-labelledby="headingOne"
-                        data-bs-parent="#sidenavAccordion">
+    <div class="collapse" id="collapseNew" aria-labelledby="headingOne"
+        data-bs-parent="#sidenavAccordion">
                         <nav>
 
                             <a class="nav-link" href="lancamento_receita">
@@ -49,8 +49,8 @@
                             </a>
                         </nav>
                     </div>
-                    <a class="nav-link collapsed" href="page" data-bs-toggle="collapse"
-                        data-bs-target="#collapseLayouts" aria-expanded="false" aria-controls="collapseLayouts">
+    <a class="nav-link collapsed" href="page" data-bs-toggle="collapse"
+        data-bs-target="#collapseTrack" aria-expanded="false" aria-controls="collapseTrack">
                         <div class="sb-nav-link-icon">
                             <i class="fa-solid fa-eye"></i>
                         </div>
@@ -59,8 +59,8 @@
                             <i class="fas fa-angle-down"></i>
                         </div>
                     </a>
-                    <div class="collapse" id="collapseLayouts" aria-labelledby="headingOne"
-                        data-bs-parent="#sidenavAccordion">
+    <div class="collapse" id="collapseTrack" aria-labelledby="headingOne"
+        data-bs-parent="#sidenavAccordion">
                         <nav class="sb-sidenav-menu-nested nav">
                             <a class="nav-link" href="listar_registros">Extrato de movimentação</a>
                             <a class="nav-link" href="pagina_em_branco">Pagina em pagina-branco</a>


### PR DESCRIPTION
## Summary
- assign unique collapse IDs for "Novo Registro" and "Acompanhamento" sections so they toggle independently

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68463b8c6d44832cb0fe5cd5d29788a5