### PR TITLE
Fix responsive tables on mobile

### DIFF
--- a/public/css/dashboard-theme.css
+++ b/public/css/dashboard-theme.css
@@ -29,6 +29,14 @@ table.modern-table tbody tr:hover {
     background-color: rgba(0, 0, 0, 0.07);
 }
 
+@media (max-width: 767.98px) {
+    table.modern-table {
+        display: block;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
 /* ------------ Form enhancements ------------ */
 .form-control {
     padding: 0.75rem 1rem;

--- a/public/html/categoria.html
+++ b/public/html/categoria.html
@@ -111,6 +111,7 @@
                                             </form>
                                         </div>
                                     </div>
+                                    <div class="table-responsive">
                                     <table class="table table-striped table-hover table-bordered modern-table">
                                         <thead>
                                             <tr>
@@ -123,6 +124,7 @@
                                         <tbody id="corpoTabela">
                                         </tbody>
                                     </table>
+                                    </div>
                                 </div>
                             </div>
 

--- a/public/html/cobranca.html
+++ b/public/html/cobranca.html
@@ -93,6 +93,7 @@
                                     </form>
                                 </div>
                             </div>
+                            <div class="table-responsive">
                             <table class="table table-striped table-hover table-bordered modern-table">
                                 <thead>
                                     <tr>
@@ -103,6 +104,7 @@
                                 <tbody id="corpoTabela">
                                 </tbody>
                             </table>
+                            </div>
                         </div>
                     </div>
 

--- a/public/html/conta.html
+++ b/public/html/conta.html
@@ -79,6 +79,7 @@
                                     <div class="d-flex justify-content-between mb-3">
                                         <button id="novoConta" class="btn btn-primary">Novo</button>
                                     </div>
+                                    <div class="table-responsive">
                                     <table class="table table-striped table-hover table-bordered modern-table">
                                         <thead>
                                             <tr>
@@ -91,6 +92,7 @@
                                         <tbody id="corpoTabela">
                                         </tbody>
                                     </table>
+                                    </div>
                                 </div>
                             </div>
 

--- a/public/html/listar_registros.html
+++ b/public/html/listar_registros.html
@@ -65,6 +65,7 @@
                 <div class="card">
                     <div class="card-body">
                         <input id="buscaRegistro" class="form-control mb-3" style="max-width:200px;" placeholder="Buscar">
+                        <div class="table-responsive">
                         <table class="table table-striped table-hover table-bordered modern-table">
                             <thead>
                                 <tr>
@@ -84,6 +85,7 @@
                                 </tr>
                             </tbody>
                         </table>
+                        </div>
 
                         <!-- Paginação -->
                         <div>

--- a/public/html/page.html
+++ b/public/html/page.html
@@ -131,6 +131,7 @@
                 <a href="dash"><button id="btnVoltar" class="btn btn-primary" type="submit">Voltar</button> </a>
                 <button id="btnMostrar" class="btn btn-success" type="submit">Buscar</button>
                 <button id="btnDeleteAll" class="btn btn-danger">Apagar Tudo</button>
+                <div class="table-responsive">
                 <table class="table table-bordered table-striped table-hover modern-table mt-3">
                     <thead>
                         <tr>
@@ -143,6 +144,7 @@
                     <tbody id="corpoTabela">
                     </tbody>
                 </table>
+                </div>
 
 
         </div>


### PR DESCRIPTION
## Summary
- wrap tables in a responsive container
- allow modern tables to scroll horizontally on small screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68463bb8b510832cbec424610e00cfaa