### PR TITLE
Adjust dashboard card order

### DIFF
--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -66,6 +66,17 @@
                     </ol>
                     <div class="row justify-content-center">
                         <div class="col-xl-4 col-md-6">
+                            <div class="card dashboard-card card-purple mb-4">
+                                <div class="card-body">Saldo: R$<span id="saldo">0.00</span> <i id="toggleSaldo" class="fas fa-eye ms-2" style="cursor: pointer;"></i></div>
+                                <div class="card-footer d-flex align-items-center justify-content-between">
+                                    <a class="small stretched-link" href="contas">Ver mais</a>
+                                    <div class="small">
+                                        <i class="fas fa-angle-right"></i>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-xl-4 col-md-6">
                             <div class="card dashboard-card card-blue mb-4">
                                 <div class="card-body">Extrato de movimentação</div>
                                 <div class="card-footer d-flex align-items-center justify-content-between">
@@ -81,17 +92,6 @@
                                 <div class="card-body">Suas Cobranças</div>
                                 <div class="card-footer d-flex align-items-center justify-content-between">
                                     <a class="small stretched-link" href="cobranca">Ver mais</a>
-                                    <div class="small">
-                                        <i class="fas fa-angle-right"></i>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xl-4 col-md-6">
-                            <div class="card dashboard-card card-purple mb-4">
-                                <div class="card-body">Saldo: R$<span id="saldo">0.00</span> <i id="toggleSaldo" class="fas fa-eye ms-2" style="cursor: pointer;"></i></div>
-                                <div class="card-footer d-flex align-items-center justify-content-between">
-                                    <a class="small stretched-link" href="contas">Ver mais</a>
                                     <div class="small">
                                         <i class="fas fa-angle-right"></i>
                                     </div>


### PR DESCRIPTION
## Summary
- reorder dashboard cards so account balance appears first

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846444c3bfc832c92d065c7d60dca97