### PR TITLE
Fix dashboard balance visibility toggle

### DIFF
--- a/public/js/saldo.js
+++ b/public/js/saldo.js
@@ -25,7 +25,8 @@ document.addEventListener("DOMContentLoaded", function () {
     atualizarExibicao();
 
     if (toggle) {
-        toggle.addEventListener("click", function () {
+        toggle.addEventListener("click", function (e) {
+            e.stopPropagation();
             visivel = !visivel;
             localStorage.setItem("saldoVisivel", visivel);
             atualizarExibicao();


### PR DESCRIPTION
## Summary
- prevent balance eye icon from triggering the stretched link

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684646f39638832c8456277da3692c02