### PR TITLE
Add credit card support

### DIFF
--- a/controllers/cartaoController.js
+++ b/controllers/cartaoController.js
@@ -1,0 +1,28 @@
+const pool = require('../db/db.js');
+
+exports.insertCartao = async (req, res) => {
+    const { ccusucod, ccdes, cclimite, ccfechamento, ccvencimento } = req.body;
+    const limite = parseFloat(cclimite.replace(',', '.'));
+    try {
+        const result = await pool.query(
+            'INSERT INTO cartaocredito (ccusucod, ccdes, cclimite, ccfechamento, ccvencimento) VALUES ($1,$2,$3,$4,$5) RETURNING *',
+            [ccusucod, ccdes, limite, ccfechamento, ccvencimento]
+        );
+        res.status(201).json(result.rows[0]);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Erro ao inserir cartao de credito' });
+    }
+};
+
+exports.listarCartoes = async (req, res) => {
+    const { id } = req.params;
+    try {
+        const result = await pool.query('SELECT * FROM cartaocredito WHERE ccusucod = $1 ORDER BY cccod', [id]);
+        res.status(200).json(result.rows);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Erro ao buscar cartoes' });
+    }
+};
+

--- a/controllers/cartaoGastoController.js
+++ b/controllers/cartaoGastoController.js
@@ -1,0 +1,32 @@
+const pool = require('../db/db.js');
+
+exports.inserirGasto = async (req, res) => {
+    const { ccid, catcod, descricao, valor, data, mesfat, usucod } = req.body;
+    const v = parseFloat(valor.replace(',', '.'));
+    try {
+        const result = await pool.query(
+            'INSERT INTO gastocredito (ccid, catcod, descricao, valor, data, mesfat, usucod) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *',
+            [ccid, catcod, descricao, v, data, mesfat, usucod]
+        );
+        res.status(201).json(result.rows[0]);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Erro ao inserir gasto do cartao' });
+    }
+};
+
+exports.listarGastos = async (req, res) => {
+    const { id } = req.params;
+    try {
+        const result = await pool.query(
+            'SELECT * FROM gastocredito WHERE usucod = $1 ORDER BY data DESC',
+            [id]
+        );
+        res.status(200).json(result.rows);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Erro ao buscar gastos' });
+    }
+};
+
+

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ const contaTipoRoutes = require('./routes/contaTipoRoutes');
 const categoriaController = require('./routes/categoriaRoutes');
 const naturezaController = require('./routes/naturezaRoutes');
 const transfController = require('./routes/transfRoutes');
+const cartaoRoutes = require('./routes/cartaoRoutes');
+const cartaoGastoRoutes = require('./routes/cartaoGastoRoutes');
 const app = express();
 
 
@@ -73,6 +75,8 @@ app.use(naturezaController);
 app.use(categoriaController);
 app.use(contaTipoRoutes);
 app.use(contaRoutes);
+app.use(cartaoRoutes);
+app.use(cartaoGastoRoutes);
 app.use(docRoutes);
 app.use(tcRoutes);
 app.use('/', loginRoutes);
@@ -117,6 +121,12 @@ app.get('/contas', autenticarToken, (req, res) => {
 });
 app.get('/conta_nova', autenticarToken, (req, res) => {
   res.sendFile(__dirname + '/public/html/conta_nova.html')
+});
+app.get('/cartao_credito', autenticarToken, (req, res) => {
+  res.sendFile(__dirname + '/public/html/cartao_credito.html')
+});
+app.get('/gasto_credito', autenticarToken, (req, res) => {
+  res.sendFile(__dirname + '/public/html/gasto_credito.html')
 });
 app.get('/pagina_em_branco', autenticarToken, (req, res) => {
   res.sendFile(__dirname + '/public/html/pagina-branco.html')

--- a/public/html/cartao_credito.html
+++ b/public/html/cartao_credito.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Ulife UCtrl</title>
+    <link rel="shortcut icon" href="../img/favicon.png" type="image/x-icon">
+    <link href="../css/styles-bootstrap.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../login/css/main.css">
+    <link rel="stylesheet" href="../css/dashboard-theme.css">
+    <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>
+</head>
+<body class="sb-nav-fixed login-bg">
+<nav class="sb-topnav navbar navbar-expand navbar-dark bg-medium-blue-rgb">
+    <a class="navbar-brand ps-3" href="dash">
+        <img src="../img/logo-tamanho-normal.png" width="30" height="30" alt="">
+        Ulife UCtrl
+    </a>
+    <button class="btn btn-link btn-sm order-1 order-lg-0 me-4 me-lg-0" id="sidebarToggle" href="#!">
+        <i class="fas fa-bars"></i>
+    </button>
+    <form class="d-none d-md-inline-block form-inline ms-auto me-0 me-md-3 my-2 my-md-0">
+        <div class="input-group">
+            <label style="color: aliceblue;" id="cronometro"></label>
+        </div>
+    </form>
+    <ul class="navbar-nav ms-auto ms-md-0 me-3 me-lg-4">
+        <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" id="navbarDropdown" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false"><i class="fas fa-user fa-fw"></i></a>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+                <li><a class="dropdown-item" href="perfil">Configurações</a></li>
+                <li><hr class="dropdown-divider" /></li>
+                <li><a class="dropdown-item" id="buttonSair">sair</a></li>
+            </ul>
+        </li>
+    </ul>
+</nav>
+<div id="layoutSidenav">
+    <div id="sidebar-container"></div>
+    <div id="layoutSidenav_content">
+        <main>
+            <div class="row">
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h3><i class="fas fa-credit-card"></i> Cartões de Crédito</h3>
+                    </div>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between mb-3">
+                        <button id="novoCartao" class="btn btn-primary">Novo</button>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover table-bordered modern-table">
+                            <thead>
+                                <tr>
+                                    <th>Cartão</th>
+                                    <th>Limite</th>
+                                    <th>Fechamento</th>
+                                    <th>Vencimento</th>
+                                </tr>
+                            </thead>
+                            <tbody id="corpoTabela"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <!-- Modal novo cartao -->
+            <div class="modal fade" id="modalNovoCartao" tabindex="-1" aria-labelledby="modalNovoLabel" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <form id="formCartao">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="modalNovoLabel">Novo Cartão</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <input id="usucod" type="hidden" name="ccusucod" value="">
+                                <div class="form-group mb-2">
+                                    <label>Nome do Cartão:</label>
+                                    <input type="text" name="ccdes" class="form-control" required>
+                                </div>
+                                <div class="form-group mb-2">
+                                    <label>Limite:</label>
+                                    <input type="text" name="cclimite" class="form-control" required placeholder="R$ 0,00">
+                                </div>
+                                <div class="form-group mb-2">
+                                    <label>Dia de Fechamento:</label>
+                                    <input type="number" name="ccfechamento" class="form-control" required>
+                                </div>
+                                <div class="form-group mb-2">
+                                    <label>Dia de Vencimento:</label>
+                                    <input type="number" name="ccvencimento" class="form-control" required>
+                                </div>
+                                <div class="alert alert-success mt-2" id="alerta-sucess" style="display: none;"></div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                                <button class="btn btn-success" type="submit">Salvar</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+<script src="/config.js"></script>
+<script src="../js/usucod.js"></script>
+<script src="../js/cartao_credito.js"></script>
+<script src="../js/cronometro.js"></script>
+<script src="../js/sidebar.js"></script>
+<script src="../js/logout.js"></script>
+<script src="../js/scripts.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/html/gasto_credito.html
+++ b/public/html/gasto_credito.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Ulife UCtrl</title>
+    <link rel="shortcut icon" href="../img/favicon.png" type="image/x-icon">
+    <link href="../css/styles-bootstrap.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../login/css/main.css">
+    <link rel="stylesheet" href="../css/dashboard-theme.css">
+    <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>
+</head>
+<body class="sb-nav-fixed login-bg">
+<nav class="sb-topnav navbar navbar-expand navbar-dark bg-medium-blue-rgb">
+    <a class="navbar-brand ps-3" href="dash">
+        <img src="../img/logo-tamanho-normal.png" width="30" height="30" alt="">
+        Ulife UCtrl
+    </a>
+    <button class="btn btn-link btn-sm order-1 order-lg-0 me-4 me-lg-0" id="sidebarToggle" href="#!">
+        <i class="fas fa-bars"></i>
+    </button>
+    <form class="d-none d-md-inline-block form-inline ms-auto me-0 me-md-3 my-2 my-md-0">
+        <div class="input-group">
+            <label style="color: aliceblue;" id="cronometro"></label>
+        </div>
+    </form>
+    <ul class="navbar-nav ms-auto ms-md-0 me-3 me-lg-4">
+        <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" id="navbarDropdown" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false"><i class="fas fa-user fa-fw"></i></a>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+                <li><a class="dropdown-item" href="perfil">Configurações</a></li>
+                <li><hr class="dropdown-divider" /></li>
+                <li><a class="dropdown-item" id="buttonSair">sair</a></li>
+            </ul>
+        </li>
+    </ul>
+</nav>
+<div id="layoutSidenav">
+    <div id="sidebar-container"></div>
+    <div id="layoutSidenav_content">
+        <main>
+            <div class="row">
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h3><i class="fas fa-credit-card"></i> Gastos no Crédito</h3>
+                    </div>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between mb-3">
+                        <button id="novoGasto" class="btn btn-primary">Novo</button>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover table-bordered modern-table">
+                            <thead>
+                                <tr>
+                                    <th>Data</th>
+                                    <th>Descrição</th>
+                                    <th>Valor</th>
+                                    <th>Cartão</th>
+                                    <th>Categoria</th>
+                                    <th>Mês Fatura</th>
+                                </tr>
+                            </thead>
+                            <tbody id="corpoTabela"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <!-- Modal novo gasto -->
+            <div class="modal fade" id="modalNovoGasto" tabindex="-1" aria-labelledby="modalNovoGastoLabel" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <form id="formGasto">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="modalNovoGastoLabel">Novo Gasto</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <input id="usucod" type="hidden" name="usucod" value="">
+                                <div class="form-group mb-2">
+                                    <label>Descrição:</label>
+                                    <input type="text" name="descricao" class="form-control" required>
+                                </div>
+                                <div class="form-group mb-2">
+                                    <label>Valor:</label>
+                                    <input type="text" name="valor" class="form-control" required placeholder="R$ 0,00">
+                                </div>
+                                <div class="form-group mb-2">
+                                    <label>Data:</label>
+                                    <input type="date" name="data" class="form-control" required>
+                                </div>
+                                <div class="form-group mb-2">
+                                    <label>Mês da Fatura:</label>
+                                    <input type="month" name="mesfat" class="form-control" required>
+                                </div>
+                                <div class="form-group mb-2">
+                                    <label>Categoria:</label>
+                                    <select id="categoria" name="catcod" class="form-control" required></select>
+                                </div>
+                                <div class="form-group mb-2">
+                                    <label>Cartão:</label>
+                                    <select id="cartao" name="ccid" class="form-control" required></select>
+                                </div>
+                                <div class="alert alert-success mt-2" id="alerta-sucess" style="display: none;"></div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                                <button class="btn btn-success" type="submit">Salvar</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+<script src="/config.js"></script>
+<script src="../js/usucod.js"></script>
+<script src="../js/gasto_credito.js"></script>
+<script src="../js/cronometro.js"></script>
+<script src="../js/sidebar.js"></script>
+<script src="../js/logout.js"></script>
+<script src="../js/scripts.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/html/sidebar.html
+++ b/public/html/sidebar.html
@@ -72,6 +72,12 @@
                         </div>
                         Contas
                     </a>
+                    <a class="nav-link" href="cartao_credito">
+                        <div class="sb-nav-link-icon ">
+                            <i class="fas fa-credit-card"></i>
+                        </div>
+                        Cartão de Crédito
+                    </a>
                     <a class="nav-link" href="categoria">
                         <div class="sb-nav-link-icon ">
                             <i class="fas fa-tasks"></i>

--- a/public/js/cartao_credito.js
+++ b/public/js/cartao_credito.js
@@ -1,0 +1,50 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('/api/dadosUserLogado')
+    .then(res => res.json())
+    .then(user => fetch(`${BASE_URL}/cartao/${user.usucod}`))
+    .then(res => res.json())
+    .then(cartoes => preencherTabela(cartoes))
+    .catch(err => console.error(err));
+});
+
+function preencherTabela(cartoes) {
+  const corpo = document.getElementById('corpoTabela');
+  if (!corpo) return;
+  corpo.innerHTML = '';
+  cartoes.forEach(c => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${c.ccdes}</td><td>${c.cclimite}</td><td>${c.ccfechamento}</td><td>${c.ccvencimento}</td>`;
+    corpo.appendChild(tr);
+  });
+}
+
+const btnNovo = document.getElementById('novoCartao');
+const modalEl = document.getElementById('modalNovoCartao');
+const modalCartao = modalEl ? new bootstrap.Modal(modalEl) : null;
+btnNovo?.addEventListener('click', () => modalCartao?.show());
+
+const form = document.getElementById('formCartao');
+form?.addEventListener('submit', e => {
+  e.preventDefault();
+  const data = Object.fromEntries(new FormData(form).entries());
+  fetch(`${BASE_URL}/cartao`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  })
+    .then(res => res.json())
+    .then(() => {
+      modalCartao?.hide();
+      form.reset();
+      document.getElementById('alerta-sucess').style.display = 'block';
+      setTimeout(() => {
+        document.getElementById('alerta-sucess').style.display = 'none';
+      }, 1500);
+      return fetch('/api/dadosUserLogado');
+    })
+    .then(res => res.json())
+    .then(user => fetch(`${BASE_URL}/cartao/${user.usucod}`))
+    .then(res => res.json())
+    .then(cartoes => preencherTabela(cartoes))
+    .catch(err => console.error(err));
+});

--- a/public/js/gasto_credito.js
+++ b/public/js/gasto_credito.js
@@ -1,0 +1,69 @@
+document.addEventListener('DOMContentLoaded', () => {
+  carregarTabelas();
+});
+
+function carregarTabelas() {
+  fetch('/api/dadosUserLogado')
+    .then(res => res.json())
+    .then(user => Promise.all([
+      fetch(`${BASE_URL}/cartao/gasto/${user.usucod}`).then(r => r.json()),
+      fetch(`${BASE_URL}/catTodosDespesa/${user.usucod}`).then(r => r.json()),
+      fetch(`${BASE_URL}/cartao/${user.usucod}`).then(r => r.json())
+    ]))
+    .then(([gastos, categorias, cartoes]) => {
+      preencherTabela(gastos);
+      popularSelect('categoria', categorias, 'catcod', 'catdes');
+      popularSelect('cartao', cartoes, 'cccod', 'ccdes');
+    })
+    .catch(err => console.error(err));
+}
+
+function popularSelect(id, dados, valueField, textField) {
+  const select = document.getElementById(id);
+  if (!select) return;
+  select.innerHTML = '';
+  dados.forEach(d => {
+    const opt = document.createElement('option');
+    opt.value = d[valueField];
+    opt.textContent = d[textField];
+    select.appendChild(opt);
+  });
+}
+
+function preencherTabela(gastos) {
+  const corpo = document.getElementById('corpoTabela');
+  if (!corpo) return;
+  corpo.innerHTML = '';
+  gastos.forEach(g => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${g.data.split('T')[0]}</td><td>${g.descricao}</td><td>${g.valor}</td><td>${g.ccdes}</td><td>${g.catdes}</td><td>${g.mesfat}</td>`;
+    corpo.appendChild(tr);
+  });
+}
+
+const btnNovo = document.getElementById('novoGasto');
+const modalEl = document.getElementById('modalNovoGasto');
+const modalGasto = modalEl ? new bootstrap.Modal(modalEl) : null;
+btnNovo?.addEventListener('click', () => modalGasto?.show());
+
+const form = document.getElementById('formGasto');
+form?.addEventListener('submit', e => {
+  e.preventDefault();
+  const data = Object.fromEntries(new FormData(form).entries());
+  fetch(`${BASE_URL}/cartao/gasto`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  })
+    .then(res => res.json())
+    .then(() => {
+      modalGasto?.hide();
+      form.reset();
+      document.getElementById('alerta-sucess').style.display = 'block';
+      setTimeout(() => {
+        document.getElementById('alerta-sucess').style.display = 'none';
+      }, 1500);
+      carregarTabelas();
+    })
+    .catch(err => console.error(err));
+});

--- a/routes/cartaoGastoRoutes.js
+++ b/routes/cartaoGastoRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const cartaoGastoController = require('../controllers/cartaoGastoController');
+const autenticarToken = require('../src/middleware/authMiddleware');
+
+router.post('/cartao/gasto', autenticarToken, cartaoGastoController.inserirGasto);
+router.get('/cartao/gasto/:id', autenticarToken, cartaoGastoController.listarGastos);
+
+module.exports = router;

--- a/routes/cartaoRoutes.js
+++ b/routes/cartaoRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const cartaoController = require('../controllers/cartaoController');
+const autenticarToken = require('../src/middleware/authMiddleware');
+
+router.post('/cartao', autenticarToken, cartaoController.insertCartao);
+router.get('/cartao/:id', autenticarToken, cartaoController.listarCartoes);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add controllers for credit card and credit card spending
- create routes for managing credit cards and expenses
- expose new endpoints in main server
- link new pages in sidebar
- add pages and scripts to handle credit card data and expenses

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684647e3f5b0832ca8c2811794b82c6e