### PR TITLE
Move banking links in sidebar

### DIFF
--- a/public/html/sidebar.html
+++ b/public/html/sidebar.html
@@ -11,6 +11,18 @@
                         </div>
                         Visão Geral
                     </a>
+                    <a class="nav-link" href="contas">
+                        <div class="sb-nav-link-icon ">
+                            <i class="fas fa-landmark"></i>
+                        </div>
+                        Contas
+                    </a>
+                    <a class="nav-link" href="cartao_credito">
+                        <div class="sb-nav-link-icon ">
+                            <i class="fas fa-credit-card"></i>
+                        </div>
+                        Cartão de Crédito
+                    </a>
 
     <a class="nav-link collapsed" href="page" data-bs-toggle="collapse"
         data-bs-target="#collapseNew" aria-expanded="false" aria-controls="collapseNew">
@@ -94,27 +106,11 @@
                             </a>
                         </nav>
                         <nav>
-                            <a class="nav-link" href="cartao_credito">
-                                <div class="sb-nav-link-icon ">
-                                    <i class="fas fa-credit-card"></i>
-                                </div>
-                                Cartão de Crédito
-                            </a>
-                        </nav>
-                        <nav>
                             <a class="nav-link" href="categoria">
                                 <div class="sb-nav-link-icon ">
                                     <i class="fas fa-tasks"></i>
                                 </div>
                                 Categorias
-                            </a>
-                        </nav>
-                        <nav>
-                            <a class="nav-link" href="contas">
-                                <div class="sb-nav-link-icon ">
-                                    <i class="fas fa-landmark"></i>
-                                </div>
-                                Contas
                             </a>
                         </nav>
                     </div>


### PR DESCRIPTION
## Summary
- show `Contas` and `Cartão de Crédito` directly in sidebar
- keep `Configurações` menu without these items

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472227b32c832cb2b722fbe8a973e5