### PR TITLE
Modern toast alerts on accounts page

### DIFF
--- a/public/html/conta.html
+++ b/public/html/conta.html
@@ -154,7 +154,7 @@
     <script src="../js/conta.js"></script>
     <script src="../js/cronometro.js"></script>
     <script src="../js/sidebar.js" ></script>
-    <script src="../js/logout.js"></script> 
+    <script src="../js/logout.js"></script>
     <!--Bootstrap Scripts-->
     <script src="../js/scripts.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
@@ -170,6 +170,17 @@
     <!--Fim-->
     <!-- <script src="../../src/js/datatables-simple-demo.js"></script>Organiza a tabela -->
 
+    <!-- Toast para mensagens -->
+    <div class="position-fixed top-0 end-0 p-3" style="z-index: 1080">
+        <div id="toastConta" class="toast align-items-center text-white bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="d-flex">
+                <div class="toast-body">
+                    Mensagem
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+        </div>
+    </div>
 
 
 </body>

--- a/public/js/conta.js
+++ b/public/js/conta.js
@@ -1,3 +1,14 @@
+function showToast(message, type = 'success') {
+  const toastEl = document.getElementById('toastConta');
+  if (!toastEl) return;
+  const body = toastEl.querySelector('.toast-body');
+  body.textContent = message;
+  toastEl.classList.remove('bg-success', 'bg-danger');
+  toastEl.classList.add(type === 'success' ? 'bg-success' : 'bg-danger');
+  const toast = bootstrap.Toast.getOrCreateInstance(toastEl);
+  toast.show();
+}
+
 document.addEventListener("DOMContentLoaded", function () {
   fetch('/api/dadosUserLogado')
     .then(res => res.json())
@@ -92,7 +103,7 @@ if (formElem) formElem.addEventListener("submit", function (e) {
       }, 1000);
     })
     .catch(erro => {
-      alert("Erro ao salvar os dados.");
+      showToast("Erro ao salvar os dados.", "danger");
       console.error(erro);
     });
 });
@@ -134,12 +145,12 @@ window.deletar = function (id) {
     })
         .then(res => {
             if (res.status === 200) {
-                alert("Registro deletado com sucesso!");
+                showToast("Registro deletado com sucesso!", "success");
                 location.reload();
             } else if (res.status === 500) {
-                alert("Existem registros vinculados a este item. Não é possível deletar.");
-            }else {
-                alert("Erro ao deletar o registro.");
+                showToast("Existem registros vinculados a este item. Não é possível deletar.", "danger");
+            } else {
+                showToast("Erro ao deletar o registro.", "danger");
             }
         })
         
@@ -188,7 +199,7 @@ function carregarContaParaEdicao(id) {
     })
     .catch(error => {
       console.error("Erro ao buscar dados:", error);
-      alert("Erro ao carregar os dados da conta.");
+      showToast("Erro ao carregar os dados da conta.", "danger");
     });
 }
 


### PR DESCRIPTION
## Summary
- add a Bootstrap toast container to `conta.html`
- implement `showToast` helper and replace `alert()` calls in `conta.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847452fa1c0832c999150431554802e