### PR TITLE
Update deletion flow for contas page

### DIFF
--- a/public/html/conta.html
+++ b/public/html/conta.html
@@ -147,6 +147,24 @@
 
     </div>
     </div>
+    <!-- Modal confirmacao exclusao -->
+    <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-labelledby="confirmDeleteLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="confirmDeleteLabel">Confirmar Exclusão</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    Deseja excluir esta conta?
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="button" id="btnConfirmDelete" class="btn btn-danger">Excluir</button>
+                </div>
+            </div>
+        </div>
+    </div>
     <!--Nossos Scripts-->
     <!-- <script src="../js/tcTeste.js"></script> -->
     <script src="/config.js"></script>

--- a/public/js/conta.js
+++ b/public/js/conta.js
@@ -139,26 +139,38 @@ function atualizarTabela() {
     .catch(erro => console.error(erro));
 }
 // delete
-window.deletar = function (id) {
-    if (!confirm('Deseja excluir esta conta?')) {
-        return;
-    }
+let deleteContaId = null;
+let confirmDeleteModal = null;
 
-    fetch(`${BASE_URL}/conta/${id}`, {
-        method: "DELETE"
-    })
-        .then(res => {
-            if (res.status === 200) {
-                showToast("Registro deletado com sucesso!", "success");
-                location.reload();
-            } else if (res.status === 500) {
-                showToast("Existem registros vinculados a este item. Não é possível deletar.", "danger");
-            } else {
-                showToast("Erro ao deletar o registro.", "danger");
-            }
-        })
-        
+window.deletar = function (id) {
+    deleteContaId = id;
+    confirmDeleteModal?.show();
 };
+
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('confirmDeleteModal');
+  confirmDeleteModal = modalEl ? new bootstrap.Modal(modalEl) : null;
+  const btnConfirmDelete = document.getElementById('btnConfirmDelete');
+
+  btnConfirmDelete?.addEventListener('click', () => {
+    if (!deleteContaId) return;
+
+    fetch(`${BASE_URL}/conta/${deleteContaId}`, {
+      method: "DELETE"
+    })
+      .then(res => {
+        confirmDeleteModal?.hide();
+        if (res.status === 200) {
+          showToast("Excluido com sucesso!", "success");
+          location.reload();
+        } else if (res.status === 500) {
+          showToast("Existem registros vinculados a este item. Não é possível deletar.", "danger");
+        } else {
+          showToast("Erro ao deletar o registro.", "danger");
+        }
+      });
+  });
+});
 
 document.addEventListener("DOMContentLoaded", function() {
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- switch delete confirmation to bootstrap modal on contas page
- show toast message "Excluido com sucesso" after deleting

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847480da984832cb916d7a76897248a