### PR TITLE
Fix toast message on account deletion

### DIFF
--- a/public/js/conta.js
+++ b/public/js/conta.js
@@ -161,13 +161,24 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(res => {
         confirmDeleteModal?.hide();
         if (res.status === 200) {
-          showToast("Excluido com sucesso!", "success");
-          location.reload();
-        } else if (res.status === 500) {
-          showToast("Existem registros vinculados a este item. Não é possível deletar.", "danger");
-        } else {
-          showToast("Erro ao deletar o registro.", "danger");
+          return res.json().then(data => {
+            showToast(data.message || "Excluido com sucesso!", "success");
+            setTimeout(() => location.reload(), 500);
+          });
         }
+
+        if (res.status === 500) {
+          showToast("Existem registros vinculados a este item. Não é possível deletar.", "danger");
+          return;
+        }
+
+        return res.json()
+          .then(err => {
+            showToast(err.error || "Erro ao deletar o registro.", "danger");
+          })
+          .catch(() => {
+            showToast("Erro ao deletar o registro.", "danger");
+          });
       });
   });
 });


### PR DESCRIPTION
## Summary
- fetch JSON response when deleting an account
- show the controller message in the toast and delay reload

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68474ae95694832cb584f17396f6126b