### PR TITLE
Fix layout padding for full width display

### DIFF
--- a/public/css/dashboard-theme.css
+++ b/public/css/dashboard-theme.css
@@ -117,3 +117,9 @@ form.form-inline .form-group {
     font-weight: 500;
     border-bottom: none;
 }
+
+/* Expand layouts to full width */
+.container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+}

--- a/public/login/css/main.css
+++ b/public/login/css/main.css
@@ -190,7 +190,7 @@ iframe {
 }
 
 .container-login100 {
-  width: 100%;  
+  width: 100%;
   min-height: 100vh;
   display: -webkit-box;
   display: -webkit-flex;
@@ -200,7 +200,7 @@ iframe {
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  padding: 15px;
+  padding: 0;
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;

--- a/public/register/css/register.css
+++ b/public/register/css/register.css
@@ -21,7 +21,7 @@ html, body {
   align-items: center;
   justify-content: center;
   height: 100%;
-  padding: 1rem;
+  padding: 0;
 }
 
 /* Card branco */


### PR DESCRIPTION
## Summary
- set login container padding to 0
- remove padding from register page container
- make Bootstrap `container-fluid` stretch fully by default

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68474c7305bc832cb9410a39a434e4b2