### PR TITLE
Add chart for receitas por status

### DIFF
--- a/controllers/docController.js
+++ b/controllers/docController.js
@@ -75,6 +75,22 @@ exports.listarDocsPvsRatual = async (req, res) => {
     }
 };
 
+// Lista o total de receitas baixadas (BA) e lançadas (LA) no mês atual
+exports.receitasStatusAtual = async (req, res) => {
+    const { id } = req.params;
+    const sta = ['LA', 'BA'];
+    try {
+        const result = await pool.query(
+            'select docsta, sum(docv) as total from doc where docusucod = $1 and docsta = ANY($2) and docnatcod = 2 and date_part(''month'', docdtpag) = date_part(''month'', CURRENT_DATE) group by docsta',
+            [id, sta]
+        );
+        res.status(200).json(result.rows);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Erro ao listar receitas por status' });
+    }
+};
+
 exports.listarDocsReceitas = async (req, res) => {
     try {
         const natureza = "Receita";

--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -178,6 +178,18 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row">
+                        <div class="col-xl-6">
+                            <div class="card chart-card mb-4">
+                                <div class="card-header">
+                                    <i class="fas fa-chart-bar me-1"></i>
+                                    Receitas por Status
+                                </div>
+                                <div class="card-body"><canvas id="barChartReceitaStatus" width="100%" height="40"></canvas>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
             </main>
 
         </div>
@@ -205,6 +217,7 @@
     <script src="../js/demo-charts/chart-pie-receita.js"></script>
     <script src="../js/demo-charts/chart-line-receitas-despesas.js"></script>
     <script src="../js/demo-charts/chart-bar-status-despesas.js"></script>
+    <script src="../js/demo-charts/chart-bar-receita-status.js"></script>
     <!--Fim-->
     <!-- <script src="../js/demo-charts/datatables-simple-demo.js"></script>Organiza a tabela -->
     <script src="../js/saldo.js"></script>

--- a/public/js/demo-charts/chart-bar-receita-status.js
+++ b/public/js/demo-charts/chart-bar-receita-status.js
@@ -1,0 +1,28 @@
+fetch('/api/dadosUserLogado')
+  .then(res => res.json())
+  .then(user => fetch(`${BASE_URL}/docReceitaStatusAtual/${user.usucod}`))
+  .then(res => res.json())
+  .then(data => {
+    const totals = {};
+    data.forEach(d => {
+      totals[d.docsta] = Number(d.total);
+    });
+    const labels = Object.keys(totals);
+    const valores = labels.map(l => totals[l]);
+    const ctx = document.getElementById('barChartReceitaStatus');
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Receitas',
+          data: valores,
+          backgroundColor: '#E57C23'
+        }]
+      },
+      options: {
+        legend: { display: false }
+      }
+    });
+  })
+  .catch(err => console.error('Erro ao carregar grafico receitas status:', err));

--- a/routes/docRoutes.js
+++ b/routes/docRoutes.js
@@ -7,6 +7,7 @@ router.post('/doc',autenticarToken, docController.criarDoc);
 router.get('/doc/:id',autenticarToken, docController.listarDocs);
 router.get('/docAnual/:id',autenticarToken, docController.listarDocsAnual);
 router.get('/docPvsRatual/:id',autenticarToken, docController.listarDocsPvsRatual);
+router.get('/docReceitaStatusAtual/:id',autenticarToken, docController.receitasStatusAtual);
 router.get('/doc/receitas',autenticarToken, docController.listarDocsReceitas);
 router.get('/doc/despesas',autenticarToken, docController.listarDocsDespesas);
 router.get('/doc/despesas/:id',autenticarToken, docController.listarDocsDespesasUser);


### PR DESCRIPTION
## Summary
- add controller route to list monthly receita totals by status
- expose new endpoint in `docRoutes`
- show new bar chart in dashboard
- include JS to load chart

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68486c18209c832c807b800703f1c2c4