### PR TITLE
Fix Realizado chart baseline

### DIFF
--- a/public/js/demo-charts/chart-line-receitas-despesasBA.js
+++ b/public/js/demo-charts/chart-line-receitas-despesasBA.js
@@ -34,7 +34,14 @@ fetch('/api/dadosUserLogado')
         ]
       },
       options: {
-        legend: { display: true }
+        legend: { display: true },
+        scales: {
+          yAxes: [{
+            ticks: {
+              beginAtZero: true
+            }
+          }]
+        }
       }
     });
   })


### PR DESCRIPTION
## Summary
- ensure 'Receitas vs Despesas | Realizado' chart axis starts at 0

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849f20b041c832c8483936cacccde5d