### PR TITLE
Add status tables on receita page

### DIFF
--- a/public/html/lancamento_receita.html
+++ b/public/html/lancamento_receita.html
@@ -106,12 +106,12 @@
                             <input id="buscaLancamento" class="form-control mb-3" placeholder="Buscar">
 
                             <div class="mb-2">
-                                <button class="btn btn-sm btn-outline-secondary me-2" onclick="toggleTable('pendentes')">Mostrar/Ocultar Pendentes</button>
-                                <button class="btn btn-sm btn-outline-secondary" onclick="toggleTable('recebidos')">Mostrar/Ocultar Recebidos</button>
+                                <button class="btn btn-sm btn-outline-secondary me-2" onclick="toggleTable('abertos')">Mostrar/Ocultar Abertos</button>
+                                <button class="btn btn-sm btn-outline-secondary" onclick="toggleTable('pagos')">Mostrar/Ocultar Pagos</button>
                             </div>
 
-                            <h6>Pendentes</h6>
-                            <div id="tabelaPendentes" class="table-responsive mb-3">
+                            <h6>Abertos</h6>
+                            <div id="tabelaAbertos" class="table-responsive mb-3">
                                 <table class="table table-hover">
                                     <thead>
                                         <tr>
@@ -126,12 +126,12 @@
                                             <th>Ações</th>
                                         </tr>
                                     </thead>
-                                    <tbody id="corpoTabelaPendentes"></tbody>
+                                    <tbody id="corpoTabelaAbertos"></tbody>
                                 </table>
                             </div>
 
-                            <h6>Recebidos</h6>
-                            <div id="tabelaRecebidos" class="table-responsive">
+                            <h6>Pagos</h6>
+                            <div id="tabelaPagos" class="table-responsive">
                                 <table class="table table-hover">
                                     <thead>
                                         <tr>
@@ -146,7 +146,7 @@
                                             <th>Ações</th>
                                         </tr>
                                     </thead>
-                                    <tbody id="corpoTabelaRecebidos"></tbody>
+                                    <tbody id="corpoTabelaPagos"></tbody>
                                 </table>
                             </div>
                             <!-- Modal de edição -->
@@ -299,7 +299,7 @@
         });
 
         window.toggleTable = function(tipo) {
-            const id = tipo === 'pendentes' ? 'tabelaPendentes' : 'tabelaRecebidos';
+            const id = tipo === 'abertos' ? 'tabelaAbertos' : 'tabelaPagos';
             const div = document.getElementById(id);
             div.style.display = div.style.display === 'none' ? '' : 'none';
         }

--- a/public/html/lancamento_receita.html
+++ b/public/html/lancamento_receita.html
@@ -105,8 +105,14 @@
                             <label style="margin-left: 0.5%;">Filtros de Pesquisa</label>
                             <input id="buscaLancamento" class="form-control mb-3" placeholder="Buscar">
 
-                            <div class="table-responsive">
-                                <table class="table  table-hover ">
+                            <div class="mb-2">
+                                <button class="btn btn-sm btn-outline-secondary me-2" onclick="toggleTable('pendentes')">Mostrar/Ocultar Pendentes</button>
+                                <button class="btn btn-sm btn-outline-secondary" onclick="toggleTable('recebidos')">Mostrar/Ocultar Recebidos</button>
+                            </div>
+
+                            <h6>Pendentes</h6>
+                            <div id="tabelaPendentes" class="table-responsive mb-3">
+                                <table class="table table-hover">
                                     <thead>
                                         <tr>
                                             <th>Data</th>
@@ -120,8 +126,27 @@
                                             <th>Ações</th>
                                         </tr>
                                     </thead>
-                                    <tbody id="corpoTabela">
-                                    </tbody>
+                                    <tbody id="corpoTabelaPendentes"></tbody>
+                                </table>
+                            </div>
+
+                            <h6>Recebidos</h6>
+                            <div id="tabelaRecebidos" class="table-responsive">
+                                <table class="table table-hover">
+                                    <thead>
+                                        <tr>
+                                            <th>Data</th>
+                                            <th>Valor</th>
+                                            <th>Cobrança</th>
+                                            <th>Natureza</th>
+                                            <th>Categoria</th>
+                                            <th>Conta</th>
+                                            <th>Observações</th>
+                                            <th>Status</th>
+                                            <th>Ações</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="corpoTabelaRecebidos"></tbody>
                                 </table>
                             </div>
                             <!-- Modal de edição -->
@@ -272,6 +297,12 @@
                 campoData.value = hoje;
             }
         });
+
+        window.toggleTable = function(tipo) {
+            const id = tipo === 'pendentes' ? 'tabelaPendentes' : 'tabelaRecebidos';
+            const div = document.getElementById(id);
+            div.style.display = div.style.display === 'none' ? '' : 'none';
+        }
     </script>
     <!--Bootstrap Scripts-->
     <script src="../js/scripts.js"></script>

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -7,8 +7,10 @@ document.addEventListener("DOMContentLoaded", function () {
     })
     .then((res) => res.json())
     .then((dados) => {
-      const corpoTabela = document.getElementById("corpoTabela");
-      corpoTabela.innerHTML = ""; // Limpa o conteúdo atual da tabela
+      const corpoPend = document.getElementById("corpoTabelaPendentes");
+      const corpoRec = document.getElementById("corpoTabelaRecebidos");
+      corpoPend.innerHTML = "";
+      corpoRec.innerHTML = "";
 
       dados.forEach((dado) => {
         const tr = document.createElement("tr");
@@ -43,7 +45,11 @@ document.addEventListener("DOMContentLoaded", function () {
                 <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})" title="Deletar"><i class="fa fa-trash"></i></button>
             </td>
               `;
-        corpoTabela.appendChild(tr);
+        if (dado.docsta === "LA") {
+          corpoPend.appendChild(tr);
+        } else {
+          corpoRec.appendChild(tr);
+        }
       });
     })
     .catch((erro) => console.error(erro));
@@ -62,9 +68,7 @@ window.deletar = function (id) {
     })
     .then(() => {
       alert("Registro deletado com sucesso!");
-      // Atualiza a tabela após a exclusão
-      document.getElementById("corpoTabela").innerHTML = "";
-      location.reload();
+      atualizarTabelaReceitas();
     })
     .catch((erro) => {
       alert("Erro ao deletar o registro.");
@@ -134,8 +138,10 @@ async function atualizarTabelaReceitas() {
     const despesasRes = await fetch(`${BASE_URL}/doc/receitas/${dadosUser.usucod}`);
     const dados = await despesasRes.json();
 
-    const corpoTabela = document.getElementById("corpoTabela");
-    corpoTabela.innerHTML = "";
+    const corpoPend = document.getElementById("corpoTabelaPendentes");
+    const corpoRec = document.getElementById("corpoTabelaRecebidos");
+    corpoPend.innerHTML = "";
+    corpoRec.innerHTML = "";
     dados.forEach((dado) => {
       const tr = document.createElement("tr");
       tr.style.color = dado.docsta === "LA" ? "#856404" : "#155724";
@@ -163,7 +169,11 @@ async function atualizarTabelaReceitas() {
           <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})" title="Deletar"><i class="fa fa-trash"></i></button>
         </td>
       `;
-      corpoTabela.appendChild(tr);
+      if (dado.docsta === "LA") {
+        corpoPend.appendChild(tr);
+      } else {
+        corpoRec.appendChild(tr);
+      }
     });
   } catch (erro) {
     console.error("Erro ao atualizar tabela de despesas:", erro);
@@ -365,7 +375,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const busca = document.getElementById('buscaLancamento');
   busca?.addEventListener('input', () => {
     const termo = busca.value.toLowerCase();
-    document.querySelectorAll('#corpoTabela tr').forEach(tr => {
+    document.querySelectorAll('#corpoTabelaPendentes tr, #corpoTabelaRecebidos tr').forEach(tr => {
       tr.style.display = tr.textContent.toLowerCase().includes(termo) ? '' : 'none';
     });
   });

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -7,10 +7,10 @@ document.addEventListener("DOMContentLoaded", function () {
     })
     .then((res) => res.json())
     .then((dados) => {
-      const corpoPend = document.getElementById("corpoTabelaPendentes");
-      const corpoRec = document.getElementById("corpoTabelaRecebidos");
-      corpoPend.innerHTML = "";
-      corpoRec.innerHTML = "";
+      const corpoAberto = document.getElementById("corpoTabelaAbertos");
+      const corpoPago = document.getElementById("corpoTabelaPagos");
+      corpoAberto.innerHTML = "";
+      corpoPago.innerHTML = "";
 
       dados.forEach((dado) => {
         const tr = document.createElement("tr");
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", function () {
           // tr.style.backgroundColor = "#d4edda"; // verde claro (Bootstrap success)
           tr.style.color = "#155724"; // texto escuro para contraste
         }
-        const docsta = dado.docsta === "LA" ? "Pendente" : "Recebido";
+        const docsta = dado.docsta === "LA" ? "Aberto" : "Pago";
         const dataFormatada = dado.docdtpag
           ? dado.docdtpag.split("T")[0]
           : null;
@@ -46,9 +46,9 @@ document.addEventListener("DOMContentLoaded", function () {
             </td>
               `;
         if (dado.docsta === "LA") {
-          corpoPend.appendChild(tr);
+          corpoAberto.appendChild(tr);
         } else {
-          corpoRec.appendChild(tr);
+          corpoPago.appendChild(tr);
         }
       });
     })
@@ -138,10 +138,10 @@ async function atualizarTabelaReceitas() {
     const despesasRes = await fetch(`${BASE_URL}/doc/receitas/${dadosUser.usucod}`);
     const dados = await despesasRes.json();
 
-    const corpoPend = document.getElementById("corpoTabelaPendentes");
-    const corpoRec = document.getElementById("corpoTabelaRecebidos");
-    corpoPend.innerHTML = "";
-    corpoRec.innerHTML = "";
+    const corpoAberto = document.getElementById("corpoTabelaAbertos");
+    const corpoPago = document.getElementById("corpoTabelaPagos");
+    corpoAberto.innerHTML = "";
+    corpoPago.innerHTML = "";
     dados.forEach((dado) => {
       const tr = document.createElement("tr");
       tr.style.color = dado.docsta === "LA" ? "#856404" : "#155724";
@@ -170,9 +170,9 @@ async function atualizarTabelaReceitas() {
         </td>
       `;
       if (dado.docsta === "LA") {
-        corpoPend.appendChild(tr);
+        corpoAberto.appendChild(tr);
       } else {
-        corpoRec.appendChild(tr);
+        corpoPago.appendChild(tr);
       }
     });
   } catch (erro) {
@@ -375,7 +375,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const busca = document.getElementById('buscaLancamento');
   busca?.addEventListener('input', () => {
     const termo = busca.value.toLowerCase();
-    document.querySelectorAll('#corpoTabelaPendentes tr, #corpoTabelaRecebidos tr').forEach(tr => {
+    document.querySelectorAll('#corpoTabelaAbertos tr, #corpoTabelaPagos tr').forEach(tr => {
       tr.style.display = tr.textContent.toLowerCase().includes(termo) ? '' : 'none';
     });
   });


### PR DESCRIPTION
## Summary
- split receita list into pending and received tables
- add hide/show toggle buttons
- update receita table script for two lists

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861e7952aa0832c99d2ac2d6c649a3c