### PR TITLE
Add column filters to receita tables

### DIFF
--- a/public/css/dashboard-theme.css
+++ b/public/css/dashboard-theme.css
@@ -123,3 +123,8 @@ form.form-inline .form-group {
     padding-left: 0;
     padding-right: 0;
 }
+
+.filter-label {
+    font-size: 0.75rem;
+    opacity: 0.8;
+}

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -391,21 +391,14 @@ document.addEventListener('DOMContentLoaded', () => {
     return Array.from(valores);
   }
 
-  function atualizarDatalist(indice) {
-    const listId = `filter-options-${indice}`;
-    let datalist = document.getElementById(listId);
-    if (!datalist) {
-      datalist = document.createElement('datalist');
-      datalist.id = listId;
-      document.body.appendChild(datalist);
-    }
-    datalist.innerHTML = '';
+  function atualizarSelect(indice, select) {
+    select.innerHTML = '<option value="">Todos</option>';
     coletarValoresUnicos(indice).forEach(val => {
       const opt = document.createElement('option');
       opt.value = val;
-      datalist.appendChild(opt);
+      opt.textContent = val;
+      select.appendChild(opt);
     });
-    return listId;
   }
 
   function aplicarFiltros() {
@@ -441,28 +434,25 @@ document.addEventListener('DOMContentLoaded', () => {
     [...headerRow.children].forEach((th, idx) => {
       const cell = document.createElement('th');
       cell.style.display = 'none';
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.className = 'form-control form-control-sm column-filter';
-      input.dataset.index = idx;
-      const listId = atualizarDatalist(idx);
-      input.setAttribute('list', listId);
-      input.addEventListener('input', () => {
-        const val = input.value.trim().toLowerCase();
+      const select = document.createElement('select');
+      select.className = 'form-select form-select-sm column-filter';
+      select.dataset.index = idx;
+      select.addEventListener('change', () => {
+        const val = select.value.trim().toLowerCase();
         if (val) filtros[idx] = val; else delete filtros[idx];
         aplicarFiltros();
       });
-      cell.appendChild(input);
+      cell.appendChild(select);
       filterRow.appendChild(cell);
       th.style.cursor = 'pointer';
       th.addEventListener('click', () => {
         if (cell.style.display === 'none') {
-          atualizarDatalist(idx);
+          atualizarSelect(idx, select);
           cell.style.display = '';
-          input.focus();
+          select.focus();
         } else {
           cell.style.display = 'none';
-          input.value = '';
+          select.value = '';
           delete filtros[idx];
           aplicarFiltros();
         }

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -379,6 +379,35 @@ document.addEventListener('DOMContentLoaded', () => {
   ];
   const filtros = {};
 
+  function coletarValoresUnicos(indice) {
+    const valores = new Set();
+    tables.forEach(t => {
+      if (!t) return;
+      t.querySelectorAll('tbody tr').forEach(tr => {
+        const td = tr.children[indice];
+        if (td) valores.add(td.textContent.trim());
+      });
+    });
+    return Array.from(valores);
+  }
+
+  function atualizarDatalist(indice) {
+    const listId = `filter-options-${indice}`;
+    let datalist = document.getElementById(listId);
+    if (!datalist) {
+      datalist = document.createElement('datalist');
+      datalist.id = listId;
+      document.body.appendChild(datalist);
+    }
+    datalist.innerHTML = '';
+    coletarValoresUnicos(indice).forEach(val => {
+      const opt = document.createElement('option');
+      opt.value = val;
+      datalist.appendChild(opt);
+    });
+    return listId;
+  }
+
   function aplicarFiltros() {
     tables.forEach(table => {
       if (!table) return;
@@ -416,6 +445,8 @@ document.addEventListener('DOMContentLoaded', () => {
       input.type = 'text';
       input.className = 'form-control form-control-sm column-filter';
       input.dataset.index = idx;
+      const listId = atualizarDatalist(idx);
+      input.setAttribute('list', listId);
       input.addEventListener('input', () => {
         const val = input.value.trim().toLowerCase();
         if (val) filtros[idx] = val; else delete filtros[idx];
@@ -425,8 +456,16 @@ document.addEventListener('DOMContentLoaded', () => {
       filterRow.appendChild(cell);
       th.style.cursor = 'pointer';
       th.addEventListener('click', () => {
-        cell.style.display = cell.style.display === 'none' ? '' : 'none';
-        input.focus();
+        if (cell.style.display === 'none') {
+          atualizarDatalist(idx);
+          cell.style.display = '';
+          input.focus();
+        } else {
+          cell.style.display = 'none';
+          input.value = '';
+          delete filtros[idx];
+          aplicarFiltros();
+        }
       });
     });
     thead.appendChild(filterRow);

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -395,7 +395,7 @@ document.addEventListener('DOMContentLoaded', () => {
     select.innerHTML = '<option value="">Todos</option>';
     coletarValoresUnicos(indice).forEach(val => {
       const opt = document.createElement('option');
-      opt.value = val;
+      opt.value = val.toLowerCase();
       opt.textContent = val;
       select.appendChild(opt);
     });
@@ -449,8 +449,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const select = document.createElement('select');
     select.className = 'form-select form-select-sm column-filter';
     atualizarSelect(indice, select);
+    if (filtros[indice]) select.value = filtros[indice];
     select.addEventListener('change', () => {
-      const val = select.value.trim().toLowerCase();
+      const val = select.value;
       if (val) filtros[indice] = val; else delete filtros[indice];
       aplicarFiltros();
       fecharDropdown();

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -378,6 +378,25 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelector('#tabelaPagos table')
   ];
   const filtros = {};
+  const headerMap = {};
+
+  function atualizarLabel(indice, texto) {
+    if (!headerMap[indice]) return;
+    headerMap[indice].forEach(th => {
+      let label = th.querySelector('.filter-label');
+      if (!label) {
+        label = document.createElement('div');
+        label.className = 'filter-label text-primary small';
+        th.appendChild(label);
+      }
+      if (texto) {
+        label.textContent = texto;
+        label.style.display = 'block';
+      } else {
+        label.style.display = 'none';
+      }
+    });
+  }
 
   function coletarValoresUnicos(indice) {
     const valores = new Set();
@@ -452,7 +471,13 @@ document.addEventListener('DOMContentLoaded', () => {
     if (filtros[indice]) select.value = filtros[indice];
     select.addEventListener('change', () => {
       const val = select.value;
-      if (val) filtros[indice] = val; else delete filtros[indice];
+      if (val) {
+        filtros[indice] = val.toLowerCase();
+        atualizarLabel(indice, select.options[select.selectedIndex].textContent);
+      } else {
+        delete filtros[indice];
+        atualizarLabel(indice, '');
+      }
       aplicarFiltros();
       fecharDropdown();
     });
@@ -478,6 +503,8 @@ document.addEventListener('DOMContentLoaded', () => {
     [...headerRow.children].forEach((th, idx) => {
       th.style.cursor = 'pointer';
       th.addEventListener('click', () => mostrarDropdown(th, idx));
+      if (!headerMap[idx]) headerMap[idx] = [];
+      headerMap[idx].push(th);
     });
   }
 

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -426,39 +426,58 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  let dropdownAtual = null;
+
+  function fecharDropdown() {
+    if (dropdownAtual) {
+      document.removeEventListener('click', dropdownAtual.handler);
+      dropdownAtual.remove();
+      dropdownAtual = null;
+    }
+  }
+
+  function mostrarDropdown(th, indice) {
+    fecharDropdown();
+    const rect = th.getBoundingClientRect();
+    const dropdown = document.createElement('div');
+    dropdown.style.position = 'absolute';
+    dropdown.style.left = `${rect.left + window.pageXOffset}px`;
+    dropdown.style.top = `${rect.bottom + window.pageYOffset}px`;
+    dropdown.style.minWidth = `${rect.width}px`;
+    dropdown.style.zIndex = '1000';
+
+    const select = document.createElement('select');
+    select.className = 'form-select form-select-sm column-filter';
+    atualizarSelect(indice, select);
+    select.addEventListener('change', () => {
+      const val = select.value.trim().toLowerCase();
+      if (val) filtros[indice] = val; else delete filtros[indice];
+      aplicarFiltros();
+      fecharDropdown();
+    });
+
+    dropdown.appendChild(select);
+    document.body.appendChild(dropdown);
+    select.focus();
+
+    const fecharSeFora = (e) => {
+      if (!dropdown.contains(e.target) && e.target !== th) {
+        fecharDropdown();
+      }
+    };
+    dropdown.handler = fecharSeFora;
+    document.addEventListener('click', fecharSeFora);
+    dropdownAtual = dropdown;
+  }
+
   function adicionarFiltrosColuna(table) {
     if (!table) return;
     const thead = table.querySelector('thead');
     const headerRow = thead.querySelector('tr');
-    const filterRow = document.createElement('tr');
     [...headerRow.children].forEach((th, idx) => {
-      const cell = document.createElement('th');
-      cell.style.display = 'none';
-      const select = document.createElement('select');
-      select.className = 'form-select form-select-sm column-filter';
-      select.dataset.index = idx;
-      select.addEventListener('change', () => {
-        const val = select.value.trim().toLowerCase();
-        if (val) filtros[idx] = val; else delete filtros[idx];
-        aplicarFiltros();
-      });
-      cell.appendChild(select);
-      filterRow.appendChild(cell);
       th.style.cursor = 'pointer';
-      th.addEventListener('click', () => {
-        if (cell.style.display === 'none') {
-          atualizarSelect(idx, select);
-          cell.style.display = '';
-          select.focus();
-        } else {
-          cell.style.display = 'none';
-          select.value = '';
-          delete filtros[idx];
-          aplicarFiltros();
-        }
-      });
+      th.addEventListener('click', () => mostrarDropdown(th, idx));
     });
-    thead.appendChild(filterRow);
   }
 
   tables.forEach(t => adicionarFiltrosColuna(t));

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -372,11 +372,72 @@ document.addEventListener('DOMContentLoaded', () => {
   btnNovo?.addEventListener('click', () => {
     modalNovo?.show();
   });
+
+  const tables = [
+    document.querySelector('#tabelaAbertos table'),
+    document.querySelector('#tabelaPagos table')
+  ];
+  const filtros = {};
+
+  function aplicarFiltros() {
+    tables.forEach(table => {
+      if (!table) return;
+      table.querySelectorAll('tbody tr').forEach(tr => {
+        let visivel = true;
+        for (const chave in filtros) {
+          const valor = filtros[chave];
+          if (chave === 'global') {
+            if (!tr.textContent.toLowerCase().includes(valor)) {
+              visivel = false;
+              break;
+            }
+          } else {
+            const td = tr.children[chave];
+            if (!td || !td.textContent.toLowerCase().includes(valor)) {
+              visivel = false;
+              break;
+            }
+          }
+        }
+        tr.style.display = visivel ? '' : 'none';
+      });
+    });
+  }
+
+  function adicionarFiltrosColuna(table) {
+    if (!table) return;
+    const thead = table.querySelector('thead');
+    const headerRow = thead.querySelector('tr');
+    const filterRow = document.createElement('tr');
+    [...headerRow.children].forEach((th, idx) => {
+      const cell = document.createElement('th');
+      cell.style.display = 'none';
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.className = 'form-control form-control-sm column-filter';
+      input.dataset.index = idx;
+      input.addEventListener('input', () => {
+        const val = input.value.trim().toLowerCase();
+        if (val) filtros[idx] = val; else delete filtros[idx];
+        aplicarFiltros();
+      });
+      cell.appendChild(input);
+      filterRow.appendChild(cell);
+      th.style.cursor = 'pointer';
+      th.addEventListener('click', () => {
+        cell.style.display = cell.style.display === 'none' ? '' : 'none';
+        input.focus();
+      });
+    });
+    thead.appendChild(filterRow);
+  }
+
+  tables.forEach(t => adicionarFiltrosColuna(t));
+
   const busca = document.getElementById('buscaLancamento');
   busca?.addEventListener('input', () => {
-    const termo = busca.value.toLowerCase();
-    document.querySelectorAll('#corpoTabelaAbertos tr, #corpoTabelaPagos tr').forEach(tr => {
-      tr.style.display = tr.textContent.toLowerCase().includes(termo) ? '' : 'none';
-    });
+    const val = busca.value.trim().toLowerCase();
+    if (val) filtros['global'] = val; else delete filtros['global'];
+    aplicarFiltros();
   });
 });


### PR DESCRIPTION
## Summary
- add per-column filtering logic for `lancamento_receita` tables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861f49cd69c832ca0b9d2cc07a94edf