### PR TITLE
Add separate paid and open expense tables

### DIFF
--- a/public/css/dashboard-theme.css
+++ b/public/css/dashboard-theme.css
@@ -123,3 +123,8 @@ form.form-inline .form-group {
     padding-left: 0;
     padding-right: 0;
 }
+
+.filter-label {
+    font-size: 0.75rem;
+    opacity: 0.8;
+}

--- a/public/html/lancamento_despesa.html
+++ b/public/html/lancamento_despesa.html
@@ -99,7 +99,13 @@
                             <label style="margin-left: 0.5%;">Filtros de Pesquisa</label>
                             <input id="buscaLancamento" class="form-control mb-3" placeholder="Buscar">
 
-                            <div class="table-responsive">
+                            <div class="mb-2">
+                                <button class="btn btn-sm btn-outline-secondary me-2" onclick="toggleTable('abertos')">Mostrar/Ocultar Abertos</button>
+                                <button class="btn btn-sm btn-outline-secondary" onclick="toggleTable('pagos')">Mostrar/Ocultar Pagos</button>
+                            </div>
+
+                            <h6>Abertos</h6>
+                            <div id="tabelaAbertos" class="table-responsive mb-3">
                                 <table class="table  table-hover">
                                     <thead>
                                         <tr>
@@ -114,8 +120,27 @@
                                             <th>Ações</th>
                                         </tr>
                                     </thead>
-                                    <tbody id="corpoTabela">
-                                    </tbody>
+                                    <tbody id="corpoTabelaAbertos"></tbody>
+                                </table>
+                            </div>
+
+                            <h6>Pagos</h6>
+                            <div id="tabelaPagos" class="table-responsive">
+                                <table class="table  table-hover">
+                                    <thead>
+                                        <tr>
+                                            <th>Data</th>
+                                            <th>Valor</th>
+                                            <th>Cobrança</th>
+                                            <th>Natureza</th>
+                                            <th>Categoria</th>
+                                            <th>Conta</th>
+                                            <th>Observações</th>
+                                            <th>Status</th>
+                                            <th>Ações</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="corpoTabelaPagos"></tbody>
                                 </table>
                             </div>
                             <!-- Modal de edição -->
@@ -267,6 +292,12 @@
                 campoData.value = hoje;
             }
         });
+
+        window.toggleTable = function(tipo) {
+            const id = tipo === 'abertos' ? 'tabelaAbertos' : 'tabelaPagos';
+            const div = document.getElementById(id);
+            div.style.display = div.style.display === 'none' ? '' : 'none';
+        }
     </script>
 
     <!--Bootstrap Scripts-->


### PR DESCRIPTION
## Summary
- split expenses into open/pago tables in HTML
- update Despesas JS to populate each table and handle column filters per table
- show toggle buttons to hide/show each expense table

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861f49cd69c832ca0b9d2cc07a94edf