### PR TITLE
Improve expense screen

### DIFF
--- a/public/html/lancamento_despesa.html
+++ b/public/html/lancamento_despesa.html
@@ -100,6 +100,7 @@
                             <input id="buscaLancamento" class="form-control mb-3" placeholder="Buscar">
 
                             <div class="table-responsive">
+                                <h5>Despesas Pendentes</h5>
                                 <table class="table  table-hover">
                                     <thead>
                                         <tr>
@@ -114,7 +115,28 @@
                                             <th>Ações</th>
                                         </tr>
                                     </thead>
-                                    <tbody id="corpoTabela">
+                                    <tbody id="tabelaPendentes">
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <div class="table-responsive mt-4">
+                                <h5>Despesas Pagas</h5>
+                                <table class="table  table-hover">
+                                    <thead>
+                                        <tr>
+                                            <th>Data</th>
+                                            <th>Valor</th>
+                                            <th>Cobrança</th>
+                                            <th>Natureza</th>
+                                            <th>Categoria</th>
+                                            <th>Conta</th>
+                                            <th>Observações</th>
+                                            <th>Status</th>
+                                            <th>Ações</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="tabelaPagas">
                                     </tbody>
                                 </table>
                             </div>

--- a/public/js/lancamentos_despesa.js
+++ b/public/js/lancamentos_despesa.js
@@ -7,8 +7,10 @@ document.addEventListener("DOMContentLoaded", function () {
     })
     .then((res) => res.json())
     .then((dados) => {
-      const corpoTabela = document.getElementById("corpoTabela");
-      corpoTabela.innerHTML = ""; // Limpa o conteúdo atual da tabela
+      const tabelaPendentes = document.getElementById("tabelaPendentes");
+      const tabelaPagas = document.getElementById("tabelaPagas");
+      tabelaPendentes.innerHTML = "";
+      tabelaPagas.innerHTML = "";
       dados.forEach((dado) => {
         const tr = document.createElement("tr");
         if (dado.docsta === "LA") {
@@ -40,7 +42,11 @@ document.addEventListener("DOMContentLoaded", function () {
                             <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})" title="Deletar"><i class="fa fa-trash"></i></button>
                         </td>
                     `;
-        corpoTabela.appendChild(tr);
+        if (dado.docsta === "LA") {
+          tabelaPendentes.appendChild(tr);
+        } else {
+          tabelaPagas.appendChild(tr);
+        }
       });
     })
     .catch((erro) => console.error(erro));
@@ -59,7 +65,8 @@ window.deletar = function (id) {
     .then(() => {
       alert("Registro deletado com sucesso!");
       // Atualiza a tabela após a exclusão
-      document.getElementById("corpoTabela").innerHTML = "";
+      document.getElementById("tabelaPendentes").innerHTML = "";
+      document.getElementById("tabelaPagas").innerHTML = "";
       location.reload();
     })
     .catch((erro) => {
@@ -131,8 +138,10 @@ async function atualizarTabelaDespesas() {
     const despesasRes = await fetch(`${BASE_URL}/doc/despesas/${dadosUser.usucod}`);
     const dados = await despesasRes.json();
 
-    const corpoTabela = document.getElementById("corpoTabela");
-    corpoTabela.innerHTML = "";
+    const tabelaPendentes = document.getElementById("tabelaPendentes");
+    const tabelaPagas = document.getElementById("tabelaPagas");
+    tabelaPendentes.innerHTML = "";
+    tabelaPagas.innerHTML = "";
     dados.forEach((dado) => {
       const tr = document.createElement("tr");
       tr.style.color = dado.docsta === "LA" ? "#856404" : "#155724";
@@ -160,7 +169,11 @@ async function atualizarTabelaDespesas() {
           <button class="btn btn-danger btn-sm" onclick="deletar(${dado.doccod})" title="Deletar"><i class="fa fa-trash"></i></button>
         </td>
       `;
-      corpoTabela.appendChild(tr);
+      if (dado.docsta === "LA") {
+        tabelaPendentes.appendChild(tr);
+      } else {
+        tabelaPagas.appendChild(tr);
+      }
     });
   } catch (erro) {
     console.error("Erro ao atualizar tabela de despesas:", erro);
@@ -361,7 +374,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const busca = document.getElementById('buscaLancamento');
   busca?.addEventListener('input', () => {
     const termo = busca.value.toLowerCase();
-    document.querySelectorAll('#corpoTabela tr').forEach(tr => {
+    document.querySelectorAll('#tabelaPendentes tr, #tabelaPagas tr').forEach(tr => {
       tr.style.display = tr.textContent.toLowerCase().includes(termo) ? '' : 'none';
     });
   });


### PR DESCRIPTION
## Summary
- split expense table into pending and paid sections
- update expense javascript to fill separate tables and handle search

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686204a89278832c8de8f475359062aa