### PR TITLE
Add total center text to all pie charts

### DIFF
--- a/public/js/demo-charts/chart-pie-despesa.js
+++ b/public/js/demo-charts/chart-pie-despesa.js
@@ -18,12 +18,43 @@ fetch('/api/dadosUserLogado')
     const labels = data.map((item) => item.catdes);
     const valores = data.map((item) => Number(item.docv));
 
-    const formatter = new Intl.NumberFormat("pt-BR", {
-      style: "currency",
-      currency: "BRL",
-    });
+  const formatter = new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  });
 
-    const myPieChart = new Chart(ctxDep, {
+  // Plugin para exibir o totalizador no centro do doughnut
+  const totalPlugin = {
+    id: "totalizadorDep",
+    beforeDraw: (chart) => {
+      if (chart.config.type !== "doughnut" || chart.canvas.id !== "myPieChartDep") return;
+      const width = chart.width;
+      const height = chart.height;
+      const ctx = chart.ctx;
+
+      // Calcula o total apenas das categorias visíveis
+      const data = chart.data.datasets[0].data;
+      const meta = chart.getDatasetMeta(0);
+      const total = data.reduce((acc, val, idx) => {
+        return meta.data[idx].hidden ? acc : acc + Number(val);
+      }, 0);
+
+      const fontSize = Math.max(Math.round(width / 15), 12);
+
+      ctx.save();
+      ctx.font = `bold ${fontSize}px sans-serif`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = "#000";
+      ctx.fillText(formatter.format(total), width / 2, height / 2);
+      ctx.restore();
+    },
+  };
+
+  // Registro global para funcionar no Chart.js 2.x
+  Chart.plugins.register(totalPlugin);
+
+  const myPieChart = new Chart(ctxDep, {
       type: "doughnut",
       data: {
         labels: labels,

--- a/public/js/demo-charts/chart-pie-despesaBA.js
+++ b/public/js/demo-charts/chart-pie-despesaBA.js
@@ -23,6 +23,37 @@ fetch('/api/dadosUserLogado')
       currency: "BRL",
     });
 
+    // Plugin para exibir o totalizador no centro do doughnut
+    const totalPlugin = {
+      id: "totalizadorDepBA",
+      beforeDraw: (chart) => {
+        if (chart.config.type !== "doughnut" || chart.canvas.id !== "myPieChartDepBA") return;
+        const width = chart.width;
+        const height = chart.height;
+        const ctx = chart.ctx;
+
+        // Calcula o total apenas das categorias visíveis
+        const data = chart.data.datasets[0].data;
+        const meta = chart.getDatasetMeta(0);
+        const total = data.reduce((acc, val, idx) => {
+          return meta.data[idx].hidden ? acc : acc + Number(val);
+        }, 0);
+
+        const fontSize = Math.max(Math.round(width / 15), 12);
+
+        ctx.save();
+        ctx.font = `bold ${fontSize}px sans-serif`;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillStyle = "#000";
+        ctx.fillText(formatter.format(total), width / 2, height / 2);
+        ctx.restore();
+      },
+    };
+
+    // Registro global para funcionar no Chart.js 2.x
+    Chart.plugins.register(totalPlugin);
+
     const myPieChart = new Chart(ctxDepBA, {
       type: "doughnut",
       data: {

--- a/public/js/demo-charts/chart-pie-receita.js
+++ b/public/js/demo-charts/chart-pie-receita.js
@@ -18,12 +18,43 @@ fetch('/api/dadosUserLogado')
     const labels = data.map((item) => item.catdes);
     const valores = data.map((item) => item.docv);
 
-    const formatter = new Intl.NumberFormat("pt-BR", {
-      style: "currency",
-      currency: "BRL",
-    });
+  const formatter = new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  });
 
-    const myPieChart = new Chart(ctxRec, {
+  // Plugin para exibir o totalizador no centro do doughnut
+  const totalPlugin = {
+    id: "totalizadorRec",
+    beforeDraw: (chart) => {
+      if (chart.config.type !== "doughnut" || chart.canvas.id !== "myPieChartRec") return;
+      const width = chart.width;
+      const height = chart.height;
+      const ctx = chart.ctx;
+
+      // Calcula o total apenas das categorias visíveis
+      const data = chart.data.datasets[0].data;
+      const meta = chart.getDatasetMeta(0);
+      const total = data.reduce((acc, val, idx) => {
+        return meta.data[idx].hidden ? acc : acc + Number(val);
+      }, 0);
+
+      const fontSize = Math.max(Math.round(width / 15), 12);
+
+      ctx.save();
+      ctx.font = `bold ${fontSize}px sans-serif`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = "#000";
+      ctx.fillText(formatter.format(total), width / 2, height / 2);
+      ctx.restore();
+    },
+  };
+
+  // Registro global para funcionar no Chart.js 2.x
+  Chart.plugins.register(totalPlugin);
+
+  const myPieChart = new Chart(ctxRec, {
       type: "doughnut",
       data: {
         labels: labels,

--- a/public/js/demo-charts/chart-pie-receitaLA.js
+++ b/public/js/demo-charts/chart-pie-receitaLA.js
@@ -18,12 +18,43 @@ fetch('/api/dadosUserLogado')
     const labels = data.map((item) => item.catdes);
     const valores = data.map((item) => item.docv);
 
-    const formatter = new Intl.NumberFormat("pt-BR", {
-      style: "currency",
-      currency: "BRL",
-    });
+  const formatter = new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  });
 
-    const myPieChart = new Chart(ctxRecLA, {
+  // Plugin para exibir o totalizador no centro do doughnut
+  const totalPlugin = {
+    id: "totalizadorRecLA",
+    beforeDraw: (chart) => {
+      if (chart.config.type !== "doughnut" || chart.canvas.id !== "myPieChartRecLA") return;
+      const width = chart.width;
+      const height = chart.height;
+      const ctx = chart.ctx;
+
+      // Calcula o total apenas das categorias visíveis
+      const data = chart.data.datasets[0].data;
+      const meta = chart.getDatasetMeta(0);
+      const total = data.reduce((acc, val, idx) => {
+        return meta.data[idx].hidden ? acc : acc + Number(val);
+      }, 0);
+
+      const fontSize = Math.max(Math.round(width / 15), 12);
+
+      ctx.save();
+      ctx.font = `bold ${fontSize}px sans-serif`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = "#000";
+      ctx.fillText(formatter.format(total), width / 2, height / 2);
+      ctx.restore();
+    },
+  };
+
+  // Registro global para funcionar no Chart.js 2.x
+  Chart.plugins.register(totalPlugin);
+
+  const myPieChart = new Chart(ctxRecLA, {
       type: "doughnut",
       data: {
         labels: labels,


### PR DESCRIPTION
## Summary
- add dynamic totalizer in center for Receitas recebidas
- add dynamic totalizer in center for Despesas pendentes
- add dynamic totalizer in center for Receitas pendentes
- make center total text responsive on all pie charts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861e7018ab8832c90b61870c4c3d02e