### PR TITLE
Improve responsive donut charts

### DIFF
--- a/public/css/dashboard-theme.css
+++ b/public/css/dashboard-theme.css
@@ -117,6 +117,9 @@ form.form-inline .form-group {
     font-weight: 500;
     border-bottom: none;
 }
+.chart-total {
+    font-weight: bold;
+}
 
 /* Expand layouts to full width */
 .container-fluid {

--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -139,6 +139,7 @@
                                 <div class="card-header">
                                     <i class="fas fa-chart-pie me-1"></i>
                                     Receitas recebidas
+                                    <span class="chart-total d-sm-none float-end"></span>
                                 </div>
                                 <div class="card-body"><canvas id="myPieChartRec" width="100%" height="50"></canvas>
                                 </div>
@@ -149,6 +150,7 @@
                                 <div class="card-header">
                                     <i class="fas fa-chart-pie me-1"></i>
                                     Despesas pendentes
+                                    <span class="chart-total d-sm-none float-end"></span>
                                 </div>
                                 <div class="card-body"><canvas id="myPieChartDep" width="100%" height="50"></canvas>
                                 </div>
@@ -159,6 +161,7 @@
                                 <div class="card-header">
                                     <i class="fas fa-chart-pie me-1"></i>
                                     Receitas pendentes
+                                    <span class="chart-total d-sm-none float-end"></span>
                                 </div>
                                 <div class="card-body"><canvas id="myPieChartRecLA" width="100%" height="50"></canvas>
                                 </div>
@@ -169,6 +172,7 @@
                                 <div class="card-header">
                                     <i class="fas fa-chart-pie me-1"></i>
                                     Despesas pagas
+                                    <span class="chart-total d-sm-none float-end"></span>
                                 </div>
                                 <div class="card-body"><canvas id="myPieChartDepBA" width="100%" height="50"></canvas>
                                 </div>

--- a/public/js/demo-charts/chart-pie-despesa.js
+++ b/public/js/demo-charts/chart-pie-despesa.js
@@ -23,7 +23,7 @@ fetch('/api/dadosUserLogado')
     currency: "BRL",
   });
 
-  // Plugin para exibir o totalizador no centro do doughnut
+  // Plugin para exibir o totalizador no centro do doughnut e mover para o título em telas pequenas
   const totalPlugin = {
     id: "totalizadorDep",
     beforeDraw: (chart) => {
@@ -39,12 +39,27 @@ fetch('/api/dadosUserLogado')
         return meta.data[idx].hidden ? acc : acc + Number(val);
       }, 0);
 
+      const totalFormatted = formatter.format(total);
+      const headerTotal = chart.canvas.closest('.card').querySelector('.chart-total');
+      if (headerTotal) {
+        if (window.innerWidth < 576) {
+          headerTotal.textContent = totalFormatted;
+        } else {
+          headerTotal.textContent = '';
+        }
+      }
+
+      if (window.innerWidth < 576) {
+        return; // Não desenha texto no centro em telas pequenas
+      }
+
       ctx.save();
-      ctx.font = "bold 1rem sans-serif";
+      const fontSize = Math.max(Math.min(width, height) * 0.12, 12);
+      ctx.font = `bold ${fontSize}px sans-serif`;
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
       ctx.fillStyle = "#000";
-      ctx.fillText(formatter.format(total), width / 2, height / 2);
+      ctx.fillText(totalFormatted, width / 2, height / 2);
       ctx.restore();
     },
   };

--- a/public/js/demo-charts/chart-pie-despesaBA.js
+++ b/public/js/demo-charts/chart-pie-despesaBA.js
@@ -23,7 +23,7 @@ fetch('/api/dadosUserLogado')
       currency: "BRL",
     });
 
-    // Plugin para exibir o totalizador no centro do doughnut
+    // Plugin para exibir o totalizador no centro do doughnut e mover para o título em telas pequenas
     const totalPlugin = {
       id: "totalizadorDepBA",
       beforeDraw: (chart) => {
@@ -39,12 +39,27 @@ fetch('/api/dadosUserLogado')
           return meta.data[idx].hidden ? acc : acc + Number(val);
         }, 0);
 
+        const totalFormatted = formatter.format(total);
+        const headerTotal = chart.canvas.closest('.card').querySelector('.chart-total');
+        if (headerTotal) {
+          if (window.innerWidth < 576) {
+            headerTotal.textContent = totalFormatted;
+          } else {
+            headerTotal.textContent = '';
+          }
+        }
+
+        if (window.innerWidth < 576) {
+          return; // Não desenha texto no centro em telas pequenas
+        }
+
         ctx.save();
-        ctx.font = "bold 1rem sans-serif";
+        const fontSize = Math.max(Math.min(width, height) * 0.12, 12);
+        ctx.font = `bold ${fontSize}px sans-serif`;
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.fillStyle = "#000";
-        ctx.fillText(formatter.format(total), width / 2, height / 2);
+        ctx.fillText(totalFormatted, width / 2, height / 2);
         ctx.restore();
       },
     };

--- a/public/js/demo-charts/chart-pie-receita.js
+++ b/public/js/demo-charts/chart-pie-receita.js
@@ -23,7 +23,7 @@ fetch('/api/dadosUserLogado')
     currency: "BRL",
   });
 
-  // Plugin para exibir o totalizador no centro do doughnut
+  // Plugin para exibir o totalizador no centro do doughnut e mover para o título em telas pequenas
   const totalPlugin = {
     id: "totalizadorRec",
     beforeDraw: (chart) => {
@@ -39,12 +39,27 @@ fetch('/api/dadosUserLogado')
         return meta.data[idx].hidden ? acc : acc + Number(val);
       }, 0);
 
+      const totalFormatted = formatter.format(total);
+      const headerTotal = chart.canvas.closest('.card').querySelector('.chart-total');
+      if (headerTotal) {
+        if (window.innerWidth < 576) {
+          headerTotal.textContent = totalFormatted;
+        } else {
+          headerTotal.textContent = '';
+        }
+      }
+
+      if (window.innerWidth < 576) {
+        return; // Não desenha texto no centro em telas pequenas
+      }
+
       ctx.save();
-      ctx.font = "bold 1rem sans-serif";
+      const fontSize = Math.max(Math.min(width, height) * 0.12, 12);
+      ctx.font = `bold ${fontSize}px sans-serif`;
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
       ctx.fillStyle = "#000";
-      ctx.fillText(formatter.format(total), width / 2, height / 2);
+      ctx.fillText(totalFormatted, width / 2, height / 2);
       ctx.restore();
     },
   };

--- a/public/js/demo-charts/chart-pie-receitaLA.js
+++ b/public/js/demo-charts/chart-pie-receitaLA.js
@@ -23,7 +23,7 @@ fetch('/api/dadosUserLogado')
     currency: "BRL",
   });
 
-  // Plugin para exibir o totalizador no centro do doughnut
+  // Plugin para exibir o totalizador no centro do doughnut e mover para o título em telas pequenas
   const totalPlugin = {
     id: "totalizadorRecLA",
     beforeDraw: (chart) => {
@@ -39,12 +39,27 @@ fetch('/api/dadosUserLogado')
         return meta.data[idx].hidden ? acc : acc + Number(val);
       }, 0);
 
+      const totalFormatted = formatter.format(total);
+      const headerTotal = chart.canvas.closest('.card').querySelector('.chart-total');
+      if (headerTotal) {
+        if (window.innerWidth < 576) {
+          headerTotal.textContent = totalFormatted;
+        } else {
+          headerTotal.textContent = '';
+        }
+      }
+
+      if (window.innerWidth < 576) {
+        return; // Não desenha texto no centro em telas pequenas
+      }
+
       ctx.save();
-      ctx.font = "bold 1rem sans-serif";
+      const fontSize = Math.max(Math.min(width, height) * 0.12, 12);
+      ctx.font = `bold ${fontSize}px sans-serif`;
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
       ctx.fillStyle = "#000";
-      ctx.fillText(formatter.format(total), width / 2, height / 2);
+      ctx.fillText(totalFormatted, width / 2, height / 2);
       ctx.restore();
     },
   };


### PR DESCRIPTION
## Summary
- show total value in chart header on small screens
- adjust donut center text size with chart size
- add chart-total style helper

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68654fc6b5d4832c8878af6b59fc1892