### PR TITLE
Add confirmation prompt on delete actions

### DIFF
--- a/public/js/lancamentos_despesa.js
+++ b/public/js/lancamentos_despesa.js
@@ -53,6 +53,7 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 // Deletar
 window.deletar = function (id) {
+  if (!confirm('Confirma a exclusão deste lançamento?')) return;
   fetch(`${BASE_URL}/doc/${id}`, {
     method: "PUT",
     credentials: "include", // Inclui cookies na requisição, se necessário

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -57,6 +57,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
 // Deletar
 window.deletar = function (id) {
+  if (!confirm('Confirma a exclusão deste lançamento?')) return;
   fetch(`${BASE_URL}/doc/${id}`, {
     method: "PUT",
     credentials: "include", // Inclui cookies na requisição, se necessário


### PR DESCRIPTION
## Summary
- ask for confirmation before deleting expenses
- ask for confirmation before deleting revenues

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6867031fa630832cb55a9870b1690426