### PR TITLE
Update receita cards layout

### DIFF
--- a/public/html/lancamento_despesa.html
+++ b/public/html/lancamento_despesa.html
@@ -57,36 +57,26 @@
                 
                 <div style="margin: auto;" class="row justify-content-center">
                     
-                    <div class="col-xl-3">
-                        <div class="card dashboard-card card-purple mb-4">
-                            <div class="card-body">Total de lançamentos: <span id="saldo">0</span> </div>
-                            <div class="card-footer d-flex align-items-center justify-content-between">
-                                
-                            </div>
+                    <div class="col-xl-3 col-md-6">
+                        <div class="alert alert-primary text-dark position-relative mb-4" role="alert">
+                            Total de lançamentos: <span id="saldo">0</span>
                         </div>
                     </div>
-                    <div class="col-xl-3">
-                        <div class="card dashboard-card card-orange mb-4">
-                            <div class="card-body">Total a Pagar: R$<span id="gastosNow">0.00</span> </div>
-                            <div class="card-footer d-flex align-items-center justify-content-between">
-                            </div>
+                    <div class="col-xl-3 col-md-6">
+                        <div class="alert alert-warning text-dark position-relative mb-4" role="alert">
+                            Total a Pagar: R$<span id="gastosNow">0.00</span>
                         </div>
                     </div>
-                
-                
-                    <div class="col-xl-3">
-                        <div class="card dashboard-card card-red mb-4">
-                            <div class="card-body">Total Pendente: R$<span id="despesaP">0.00</span> </div>
-                            <div class="card-footer d-flex align-items-center justify-content-between">
-                            </div>
+
+                    <div class="col-xl-3 col-md-6">
+                        <div class="alert alert-danger text-dark position-relative mb-4" role="alert">
+                            Total Pendente: R$<span id="despesaP">0.00</span>
                         </div>
                     </div>
-                    
-                    <div class="col-xl-3">
-                        <div class="card dashboard-card card-teal mb-4">
-                            <div class="card-body">A Pagar: R$<span id="totalSeguro">0.00</span> </div>
-                            <div class="card-footer d-flex align-items-center justify-content-between">
-                            </div>
+
+                    <div class="col-xl-3 col-md-6">
+                        <div class="alert alert-success text-dark position-relative mb-4" role="alert">
+                            A Pagar: R$<span id="totalSeguro">0.00</span>
                         </div>
                     </div>
                 </div>

--- a/public/html/lancamento_receita.html
+++ b/public/html/lancamento_receita.html
@@ -63,34 +63,25 @@
 
                 <div style="margin: auto;" class="row justify-content-center">
 
-                    <div class="col-xl-3">
-                        <div class="card dashboard-card card-purple mb-4">
-                            <div class="card-body">Total de lançamentos: <span id="saldo">0</span> </div>
-                            <div class="card-footer d-flex align-items-center justify-content-between">
-
-                            </div>
+                    <div class="col-xl-3 col-md-6">
+                        <div class="alert alert-primary text-dark position-relative mb-4" role="alert">
+                            Total de lançamentos: <span id="saldo">0</span>
                         </div>
                     </div>
-                    <div class="col-xl-3">
-                        <div class="card dashboard-card card-orange mb-4">
-                            <div class="card-body">Total a receber: R$<span id="gastosNow">0.00</span> </div>
-                            <div class="card-footer d-flex align-items-center justify-content-between">
-                            </div>
+                    <div class="col-xl-3 col-md-6">
+                        <div class="alert alert-warning text-dark position-relative mb-4" role="alert">
+                            Total a receber: R$<span id="gastosNow">0.00</span>
                         </div>
                     </div>
-                    <div class="col-xl-3">
-                        <div class="card dashboard-card card-red mb-4">
-                            <div class="card-body">Total Pendente: R$<span id="despesaP">0.00</span> </div>
-                            <div class="card-footer d-flex align-items-center justify-content-between">
-                            </div>
+                    <div class="col-xl-3 col-md-6">
+                        <div class="alert alert-danger text-dark position-relative mb-4" role="alert">
+                            Total Pendente: R$<span id="despesaP">0.00</span>
                         </div>
                     </div>
 
-                    <div class="col-xl-3">
-                        <div class="card dashboard-card card-teal mb-4">
-                            <div class="card-body">A receber: R$<span id="totalSeguro">0.00</span> </div>
-                            <div class="card-footer d-flex align-items-center justify-content-between">
-                            </div>
+                    <div class="col-xl-3 col-md-6">
+                        <div class="alert alert-success text-dark position-relative mb-4" role="alert">
+                            A receber: R$<span id="totalSeguro">0.00</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- adjust the cards on `lancamento_receita.html` to use the same alert style as the dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68671670f1ec832cb7456213748abff5