### PR TITLE
Add icons to dashboard alerts

### DIFF
--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -90,18 +90,21 @@
                     <div class="row justify-content-center">
                         <div class="col-xl-4 col-md-6">
                             <div class="alert alert-primary text-dark position-relative mb-4" role="alert">
+                                <i class="fas fa-wallet me-1"></i>
                                 Saldo: R$<span id="saldo">0.00</span>
                                 <a class="stretched-link" href="contas"></a>
                             </div>
                         </div>
                         <div class="col-xl-4 col-md-6">
                             <div class="alert alert-warning text-dark position-relative mb-4" role="alert">
+                                <i class="fas fa-money-bill-wave me-1"></i>
                                 Gastos hoje: R$<span id="gastosNow">0.00</span>
                             </div>
                         </div>
 
                         <div class="col-xl-4 col-md-6">
                             <div class="alert alert-success text-dark position-relative mb-4" role="alert">
+                                <i class="fas fa-hand-holding-usd me-1"></i>
                                 Receitas a receber: R$<span id="receitaP">0.00</span>
                                 <a class="stretched-link" href="lancamento_receita"></a>
                             </div>
@@ -110,17 +113,20 @@
                     <div class="row justify-content-center">
                         <div class="col-xl-4 col-md-6">
                             <div class="alert alert-danger text-dark position-relative mb-4" role="alert">
+                                <i class="fas fa-file-invoice-dollar me-1"></i>
                                 Despesas a pagar: R$<span id="despesaP">0.00</span>
                                 <a class="stretched-link" href="lancamento_despesa"></a>
                             </div>
                         </div>
                         <div class="col-xl-4 col-md-6">
                             <div class="alert alert-warning text-dark position-relative mb-4" role="alert">
+                                <i class="fas fa-credit-card me-1"></i>
                                 Gastos no crédito hoje: R$<span id="gastosNow">0.00</span>
                             </div>
                         </div>
                         <div class="col-xl-4 col-md-6">
                             <div class="alert alert-info text-dark position-relative mb-4" role="alert">
+                                <i class="fas fa-shield-alt me-1"></i>
                                 Total seguro: R$<span id="totalSeguro">0.00</span>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- show wallet icon next to saldo alert
- add icons for spending today, pending revenue, pending expenses, credit spending, and total insurance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68671aa76b08832cadb300da2589ed36