### PR TITLE
Add status filter and default dates

### DIFF
--- a/public/html/lancamento_despesa.html
+++ b/public/html/lancamento_despesa.html
@@ -89,7 +89,7 @@
                             <label style="margin-left: 0.5%;">Filtros de Pesquisa</label>
                             <div class="container-fluid p-0" id="filtrosContainer">
                                 <div class="row g-2">
-                                    <div class="col-md-4">
+                                    <div class="col-md-3">
                                         <label class="form-label">Período</label>
                                         <div class="d-flex">
                                             <input type="date" id="dataInicio" class="form-control" />
@@ -105,9 +105,17 @@
                                         <label class="form-label">Valor Máx.</label>
                                         <input type="number" step="0.01" id="valorMax" class="form-control" />
                                     </div>
-                                    <div class="col-md-3">
+                                    <div class="col-md-2">
                                         <label class="form-label">Categoria</label>
                                         <select id="categoriaFiltro" class="form-select"></select>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <label class="form-label">Status</label>
+                                        <select id="statusFiltro" class="form-select">
+                                            <option value="">Todos</option>
+                                            <option value="aberto">Abertos</option>
+                                            <option value="pago">Pagos</option>
+                                        </select>
                                     </div>
                                     <div class="col-md-1 d-flex align-items-end">
                                         <button class="btn btn-secondary w-100" id="limparFiltros">Limpar</button>

--- a/public/html/lancamento_receita.html
+++ b/public/html/lancamento_receita.html
@@ -96,7 +96,7 @@
                             <label style="margin-left: 0.5%;">Filtros de Pesquisa</label>
                             <div class="container-fluid p-0" id="filtrosContainer">
                                 <div class="row g-2">
-                                    <div class="col-md-4">
+                                    <div class="col-md-3">
                                         <label class="form-label">Período</label>
                                         <div class="d-flex">
                                             <input type="date" id="dataInicio" class="form-control" />
@@ -112,9 +112,17 @@
                                         <label class="form-label">Valor Máx.</label>
                                         <input type="number" step="0.01" id="valorMax" class="form-control" />
                                     </div>
-                                    <div class="col-md-3">
+                                    <div class="col-md-2">
                                         <label class="form-label">Categoria</label>
                                         <select id="categoriaFiltro" class="form-select"></select>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <label class="form-label">Status</label>
+                                        <select id="statusFiltro" class="form-select">
+                                            <option value="">Todos</option>
+                                            <option value="aberto">Abertos</option>
+                                            <option value="pago">Pagos</option>
+                                        </select>
                                     </div>
                                     <div class="col-md-1 d-flex align-items-end">
                                         <button class="btn btn-secondary w-100" id="limparFiltros">Limpar</button>

--- a/public/js/lancamentos_despesa.js
+++ b/public/js/lancamentos_despesa.js
@@ -525,7 +525,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const valorMin = document.getElementById('valorMin');
   const valorMax = document.getElementById('valorMax');
   const filtroCategoria = document.getElementById('categoriaFiltro');
+  const filtroStatus = document.getElementById('statusFiltro');
   const limpar = document.getElementById('limparFiltros');
+
+  const agora = new Date();
+  const inicioMes = new Date(agora.getFullYear(), agora.getMonth(), 1)
+    .toISOString()
+    .split('T')[0];
+  const fimMes = new Date(agora.getFullYear(), agora.getMonth() + 1, 0)
+    .toISOString()
+    .split('T')[0];
+  if (filtroInicio) filtroInicio.value = inicioMes;
+  if (filtroFim) filtroFim.value = fimMes;
 
   function filtrarExtras() {
     const inicio = filtroInicio.value ? new Date(filtroInicio.value) : null;
@@ -533,6 +544,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const min = parseFloat(valorMin.value.replace(',', '.'));
     const max = parseFloat(valorMax.value.replace(',', '.'));
     const cat = filtroCategoria.value.toLowerCase();
+    const status = filtroStatus.value.toLowerCase();
 
     tables.forEach(table => {
       table.querySelectorAll('tbody tr').forEach(tr => {
@@ -541,6 +553,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const dataVal = new Date(`${partes[2]}-${partes[1]}-${partes[0]}`);
         const valor = parseFloat(tr.children[1].textContent.replace(',', '.'));
         const categoria = tr.children[4].textContent.toLowerCase();
+        const statusTxt = tr.children[7].textContent.toLowerCase();
 
         let ok = true;
         if (inicio && dataVal < inicio) ok = false;
@@ -548,12 +561,13 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!isNaN(min) && valor < min) ok = false;
         if (!isNaN(max) && valor > max) ok = false;
         if (cat && !categoria.includes(cat)) ok = false;
+        if (status && !statusTxt.includes(status)) ok = false;
         tr.style.display = ok ? '' : 'none';
       });
     });
   }
 
-  [filtroInicio, filtroFim, valorMin, valorMax, filtroCategoria].forEach(el => {
+  [filtroInicio, filtroFim, valorMin, valorMax, filtroCategoria, filtroStatus].forEach(el => {
     el?.addEventListener('input', filtrarExtras);
   });
   limpar?.addEventListener('click', e => {
@@ -563,6 +577,7 @@ document.addEventListener('DOMContentLoaded', () => {
     valorMin.value = '';
     valorMax.value = '';
     filtroCategoria.value = '';
+    filtroStatus.value = '';
     filtrarExtras();
   });
 

--- a/public/js/lancamentos_receita.js
+++ b/public/js/lancamentos_receita.js
@@ -526,7 +526,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const valorMin = document.getElementById('valorMin');
   const valorMax = document.getElementById('valorMax');
   const filtroCategoria = document.getElementById('categoriaFiltro');
+  const filtroStatus = document.getElementById('statusFiltro');
   const limpar = document.getElementById('limparFiltros');
+
+  const agora = new Date();
+  const inicioMes = new Date(agora.getFullYear(), agora.getMonth(), 1)
+    .toISOString()
+    .split('T')[0];
+  const fimMes = new Date(agora.getFullYear(), agora.getMonth() + 1, 0)
+    .toISOString()
+    .split('T')[0];
+  if (filtroInicio) filtroInicio.value = inicioMes;
+  if (filtroFim) filtroFim.value = fimMes;
 
   function filtrarExtras() {
     const inicio = filtroInicio.value ? new Date(filtroInicio.value) : null;
@@ -534,6 +545,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const min = parseFloat(valorMin.value.replace(',', '.'));
     const max = parseFloat(valorMax.value.replace(',', '.'));
     const cat = filtroCategoria.value.toLowerCase();
+    const status = filtroStatus.value.toLowerCase();
 
     tables.forEach(table => {
       table.querySelectorAll('tbody tr').forEach(tr => {
@@ -542,6 +554,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const dataVal = new Date(`${partes[2]}-${partes[1]}-${partes[0]}`);
         const valor = parseFloat(tr.children[1].textContent.replace(',', '.'));
         const categoria = tr.children[4].textContent.toLowerCase();
+        const statusTxt = tr.children[7].textContent.toLowerCase();
 
         let ok = true;
         if (inicio && dataVal < inicio) ok = false;
@@ -549,12 +562,13 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!isNaN(min) && valor < min) ok = false;
         if (!isNaN(max) && valor > max) ok = false;
         if (cat && !categoria.includes(cat)) ok = false;
+        if (status && !statusTxt.includes(status)) ok = false;
         tr.style.display = ok ? '' : 'none';
       });
     });
   }
 
-  [filtroInicio, filtroFim, valorMin, valorMax, filtroCategoria].forEach(el => {
+  [filtroInicio, filtroFim, valorMin, valorMax, filtroCategoria, filtroStatus].forEach(el => {
     el?.addEventListener('input', filtrarExtras);
   });
   limpar?.addEventListener('click', e => {
@@ -564,6 +578,7 @@ document.addEventListener('DOMContentLoaded', () => {
     valorMin.value = '';
     valorMax.value = '';
     filtroCategoria.value = '';
+    filtroStatus.value = '';
     filtrarExtras();
   });
 


### PR DESCRIPTION
## Summary
- enable setting period filters to first and last day of month
- add new status filter to receita/despesa pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6867f64038f4832c932621b96f78625c